### PR TITLE
[feat-login-normal] 일반 로그인 기능 + 보안 기능 설정 구현

### DIFF
--- a/src/main/java/com/zerototen/savegame/config/Jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.zerototen.savegame.config.Jwt;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/Jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.zerototen.savegame.config.Jwt;
+
+import static com.zerototen.savegame.exception.ErrorCode.JWT_TIMEOUT;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+
+        //Content-type : application/json;charset=utf-8
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        // {"username":"loop-study", "age":20}
+        String result = objectMapper.writeValueAsString(JWT_TIMEOUT);
+        response.getWriter().write(result);
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/Jwt/JwtFilter.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/JwtFilter.java
@@ -1,0 +1,64 @@
+package com.zerototen.savegame.config.Jwt;
+
+import com.zerototen.savegame.config.RedisDao;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    private final RedisDao redisDao;
+
+    private final TokenProvider tokenProvider;
+
+    public JwtFilter(TokenProvider tokenProvider, RedisDao redisDao) {
+        this.tokenProvider = tokenProvider;
+        this.redisDao = redisDao;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+        FilterChain filterChain)
+        throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        String jwt = resolveToken(httpServletRequest);
+
+        log.info("----------------------------------");
+        log.info(jwt);
+        log.info("----------------------------------");
+
+        String requestURI = httpServletRequest.getRequestURI();
+
+        if (jwt != null && tokenProvider.validateToken(jwt)) {
+            if (redisDao.getValues(jwt) == null) {
+                Authentication authentication = tokenProvider.getAuthentication(jwt);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(),
+                    requestURI);
+            }
+        } else {
+            log.info("유효한 JWT 토큰이 없습니다, uri {}", requestURI);
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/Jwt/JwtMemberService.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/JwtMemberService.java
@@ -1,0 +1,44 @@
+package com.zerototen.savegame.config.Jwt;
+
+import static com.zerototen.savegame.exception.ErrorCode.LOGIN_CHECK_FAIL;
+
+import com.zerototen.savegame.entity.Member;
+import com.zerototen.savegame.exception.CustomException;
+import com.zerototen.savegame.repository.MemberRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Component("userDetailsService")
+@RequiredArgsConstructor
+public class JwtMemberService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(final String email) {
+        return memberRepository.findOneWithAuthoritiesByEmail(email)
+            .map(this::createMember)
+            .orElseThrow(() -> new CustomException(LOGIN_CHECK_FAIL));
+    }
+
+    private org.springframework.security.core.userdetails.User createMember(Member member) {
+
+        List<GrantedAuthority> grantedAuthorities = member.getAuthorities().stream()
+            .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName()))
+            .collect(Collectors.toList());
+        return new org.springframework.security.core.userdetails.User(member.getEmail(),
+            member.getPassword(),
+            grantedAuthorities
+        );
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/Jwt/JwtSecurityConfig.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/JwtSecurityConfig.java
@@ -1,0 +1,26 @@
+package com.zerototen.savegame.config.Jwt;
+
+import com.zerototen.savegame.config.RedisDao;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class JwtSecurityConfig extends
+    SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+
+    private final RedisDao redisDao;
+
+    public JwtSecurityConfig(TokenProvider tokenProvider, RedisDao redisDao) {
+        this.tokenProvider = tokenProvider;
+        this.redisDao = redisDao;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(tokenProvider, redisDao);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/Jwt/SecurityUtil.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/SecurityUtil.java
@@ -1,0 +1,36 @@
+package com.zerototen.savegame.config.Jwt;
+
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class SecurityUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(SecurityUtil.class);
+    private static String email;
+
+    private SecurityUtil() {
+    }
+
+    public static Optional<String> getCurrentUsername() {
+        final Authentication authentication = SecurityContextHolder.getContext()
+            .getAuthentication();
+
+        if (authentication == null) {
+            logger.debug("Security Context 인증 정보가 없습니다.");
+            return Optional.empty();
+        }
+
+        if (authentication.getPrincipal() instanceof UserDetails springSecurityUser) {
+            email = springSecurityUser.getUsername();
+        } else if (authentication.getPrincipal() instanceof String) {
+            email = (String) authentication.getPrincipal();
+        }
+
+        return Optional.ofNullable(email);
+    }
+
+}

--- a/src/main/java/com/zerototen/savegame/config/Jwt/TokenProvider.java
+++ b/src/main/java/com/zerototen/savegame/config/Jwt/TokenProvider.java
@@ -1,0 +1,120 @@
+package com.zerototen.savegame.config.Jwt;
+
+import com.zerototen.savegame.config.RedisDao;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenProvider implements InitializingBean {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+    private final String secret;
+    private final long tokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+    private final RedisDao redisDao;
+
+    private Key key;
+
+    public TokenProvider(
+        @Value("${jwt.secret}") String secret,
+        @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds,
+        @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds,
+        RedisDao redisDao) {
+        this.secret = secret;
+        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;
+        this.redisDao = redisDao;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+            .setSubject(authentication.getName())
+            .claim(AUTHORITIES_KEY, authorities)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setExpiration(validity)
+            .compact();
+    }
+
+    public String createRefreshToken(String email) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.refreshTokenValidityInMilliseconds);
+        String refreshToken = Jwts.builder()
+            .setSubject(email)
+            .setExpiration(validity)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+        redisDao.setValues(email, refreshToken, Duration.ofDays(14));
+        return refreshToken;
+    }
+
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts
+            .parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            logger.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/RedisConfig.java
+++ b/src/main/java/com/zerototen/savegame/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.zerototen.savegame.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/RedisDao.java
+++ b/src/main/java/com/zerototen/savegame/config/RedisDao.java
@@ -1,0 +1,35 @@
+package com.zerototen.savegame.config;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisDao {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RedisDao(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/RestTemplateConfig.java
+++ b/src/main/java/com/zerototen/savegame/config/RestTemplateConfig.java
@@ -1,0 +1,28 @@
+package com.zerototen.savegame.config;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+            .requestFactory(
+                () -> new BufferingClientHttpRequestFactory(
+                    new SimpleClientHttpRequestFactory()
+                )
+            ).additionalMessageConverters(
+                new StringHttpMessageConverter(
+                    StandardCharsets.UTF_8
+                )).build();
+    }
+
+}

--- a/src/main/java/com/zerototen/savegame/config/RootConfig.java
+++ b/src/main/java/com/zerototen/savegame/config/RootConfig.java
@@ -1,0 +1,22 @@
+package com.zerototen.savegame.config;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class RootConfig {
+
+    @Bean
+    public ModelMapper getMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration()
+            .setFieldMatchingEnabled(true)
+            .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
+            .setMatchingStrategy(MatchingStrategies.STRICT);
+
+        return modelMapper;
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/SecurityConfig.java
+++ b/src/main/java/com/zerototen/savegame/config/SecurityConfig.java
@@ -1,0 +1,78 @@
+package com.zerototen.savegame.config;
+
+import com.zerototen.savegame.config.Jwt.JwtAccessDeniedHandler;
+import com.zerototen.savegame.config.Jwt.JwtAuthenticationEntryPoint;
+import com.zerototen.savegame.config.Jwt.JwtSecurityConfig;
+import com.zerototen.savegame.config.Jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
+
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final RedisDao redisDao;
+    private final TokenProvider tokenProvider;
+    private final CorsFilter corsFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+            .csrf().disable()
+
+            .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            .accessDeniedHandler(jwtAccessDeniedHandler)
+
+            .and()
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+            .and()
+            .authorizeRequests()
+            .antMatchers(
+                //일반 로그인
+                "/app/sign-up", "/app/auth/login",
+
+                //이메일, 닉네임 검증
+                "/app/exist-nickname", "/app/exist-email",
+
+                // OAth2
+                "/auth/google/**",
+
+                //Swagger
+                "/v2/api-docs",
+                "/swagger-resources",
+                "/swagger-resources/**",
+                "/configuration/ui",
+                "/configuration/security",
+                "/swagger-ui.html",
+                "/webjars/**",
+                "/v3/api-docs/**",
+                "/swagger-ui/**"
+            )
+            .permitAll()
+            .anyRequest().authenticated()
+
+            .and()
+            .apply(new JwtSecurityConfig(tokenProvider, redisDao));
+    }
+}

--- a/src/main/java/com/zerototen/savegame/config/SwaggerConfig.java
+++ b/src/main/java/com/zerototen/savegame/config/SwaggerConfig.java
@@ -47,7 +47,7 @@ public class SwaggerConfig {
         return new ApiInfoBuilder()
             .title("API")
             .description("[SaveGame] REST API")
-            .contact(new Contact("[SaveGame Swagger]", "https://github.com//", "@gmail.com"))
+            .contact(new Contact("[SaveGame Swagger]", "https://github.com/", "@gmail.com"))
             .version("1.0")
             .build();
     }

--- a/src/main/java/com/zerototen/savegame/controller/MemberController.java
+++ b/src/main/java/com/zerototen/savegame/controller/MemberController.java
@@ -1,0 +1,46 @@
+package com.zerototen.savegame.controller;
+
+
+
+import com.zerototen.savegame.dto.MemberDto;
+import com.zerototen.savegame.dto.MemberDto.SaveDto;
+import com.zerototen.savegame.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("app")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 로그인
+    @PostMapping("auth/login")
+    public ResponseEntity<MemberDto.LoginDto> login(@RequestBody MemberDto.LoginDto request) {
+        return memberService.login(request);
+    }
+
+    // 회원가입
+    @PostMapping("sign-up")
+    public ResponseEntity<SaveDto> register(@RequestBody MemberDto.SaveDto request) {
+        return memberService.register(request);
+    }
+
+    @GetMapping("/exist-email")
+    public ResponseEntity<?> existEmail(@RequestParam(required = true) String email) {
+        return ResponseEntity.ok(memberService.isEmailExist(email));
+    }
+
+    @GetMapping("/exist-nickname")
+    public ResponseEntity<?> existNickname(@RequestParam(required = true) String nickname) {
+        return ResponseEntity.ok(memberService.isNicknameExist(nickname));
+    }
+
+}

--- a/src/main/java/com/zerototen/savegame/dto/MemberDto.java
+++ b/src/main/java/com/zerototen/savegame/dto/MemberDto.java
@@ -1,0 +1,153 @@
+package com.zerototen.savegame.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sun.istack.NotNull;
+import com.zerototen.savegame.entity.Member;
+import io.swagger.annotations.ApiModelProperty;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberDto implements Serializable {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DeleteDto {
+
+        private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Builder
+    public static class OfficeSaveDto {
+
+        private Long id;
+        private String email;
+        private String password;
+        private String nickname;
+        private String imageUrl;
+        private String accessToken;
+        private String refreshToken;
+
+        public static OfficeSaveDto response(Member member, String accessToken,
+            String refreshToken) {
+            return OfficeSaveDto.builder()
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Getter
+    @Builder
+    public static class SaveDto {
+
+        @ApiModelProperty(hidden = true)
+        private Long id;
+        private String nickname;
+        private String email;
+        private String password;
+        private String userImage;
+        @ApiModelProperty(hidden = true)
+        private String accessToken;
+        @ApiModelProperty(hidden = true)
+        private String refreshToken;
+
+        public static SaveDto response(Member member, String accessToken, String refreshToken) {
+            return SaveDto.builder()
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Getter
+    @Builder
+    public static class LoginDto {
+
+        private String email;
+        private String password;
+        @ApiModelProperty(hidden = true)
+        private String accessToken;
+        @ApiModelProperty(hidden = true)
+        private String refreshToken;
+
+        public static LoginDto response(String accessToken, String refreshToken) {
+            return LoginDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class reissue {
+
+        private final String pw;
+        private final String email;
+        private final String rtk;
+    }
+
+    @Data
+    @Builder
+    public static class socialLoginResponse {
+
+        private final String status;
+        private final String name;
+        private final String email;
+        private final String img;
+        private final String atk;
+        private final String rtk;
+
+        public static socialLoginResponse response(String name, String email, String img,
+            String atk, String rtk, String status) {
+            return socialLoginResponse.builder()
+                .status(status)
+                .name(name)
+                .email(email)
+                .img(img)
+                .atk(atk)
+                .rtk(rtk)
+                .build();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class DetailDto {
+
+        private Long id;
+        private String nickname;
+        private String email;
+        private String imageUrl;
+
+
+        public static DetailDto response(@NotNull Member member) {
+            return DetailDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .imageUrl(member.getImageUrl())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/zerototen/savegame/entity/Authority.java
+++ b/src/main/java/com/zerototen/savegame/entity/Authority.java
@@ -1,0 +1,29 @@
+package com.zerototen.savegame.entity;
+
+import com.sun.istack.NotNull;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Table(name = "authority")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Authority {
+
+    @Id
+    @Column(name = "authority_name", length = 50)
+    @ColumnDefault("ROLE_MEMBER")
+    @NotNull
+    private String authorityName;
+}

--- a/src/main/java/com/zerototen/savegame/entity/BaseEntity.java
+++ b/src/main/java/com/zerototen/savegame/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.zerototen.savegame.member.domain.model;
+package com.zerototen.savegame.entity;
 
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
@@ -12,8 +12,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(value = {AuditingEntityListener.class})
 public class BaseEntity {
-  @CreatedDate
-  private LocalDateTime createdAt;
-  @LastModifiedDate
-  private LocalDateTime modifiedAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/zerototen/savegame/entity/Member.java
+++ b/src/main/java/com/zerototen/savegame/entity/Member.java
@@ -1,25 +1,32 @@
-package com.zerototen.savegame.member.domain.model;
+package com.zerototen.savegame.entity;
 
-import com.zerototen.savegame.member.domain.controller.dto.SignUpForm;
 import java.time.LocalDateTime;
-import java.util.Locale;
+import java.util.Set;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.envers.AuditOverride;
 
 @Entity
+@Table(name = "member")
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
 public class Member extends BaseEntity {
 
     @Id
@@ -33,13 +40,15 @@ public class Member extends BaseEntity {
     private String imageUrl;
     private LocalDateTime deletedAt;
 
-    public static Member from(SignUpForm form) {
-        return Member.builder()
-            .email(form.getEmail().toLowerCase(Locale.ROOT))
-            .password(form.getPassword())
-            .nickname(form.getNickname())
-            .imageUrl("default.png")
-            .build();
-    }
+    @ManyToMany
+    @JoinTable(
+        name = "member_authority",
+        joinColumns = {
+        @JoinColumn(name = "id", referencedColumnName = "id")},
+        inverseJoinColumns = {
+        @JoinColumn(name = "authority_name",
+            referencedColumnName = "authority_name")}
+        )
+    private Set<Authority> authorities;
 
 }

--- a/src/main/java/com/zerototen/savegame/exception/ErrorCode.java
+++ b/src/main/java/com/zerototen/savegame/exception/ErrorCode.java
@@ -8,12 +8,20 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    //회원가입
+    WANT_SOCIAL_REGISTER(HttpStatus.BAD_REQUEST, "해당 이메일은 소셜로그인으로 진행해야 합니다."),
+    NOT_EMAIL_FORM(HttpStatus.BAD_REQUEST, "이메일 형식이 아닙니다."),
+    PASSWORD_SIZE_ERROR(HttpStatus.BAD_REQUEST, "비밀번호가 6자리 이상이여야 합니다."),
+    NOT_CONTAINS_EXCLAMATIONMARK(HttpStatus.BAD_REQUEST, "비밀번호에 특수문자가 포함되어있지 않습니다."),
+
     ALREADY_REGISTER_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용되는 닉네임입니다."),
     ALREADY_REGISTER_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용되는 이메일입니다."),
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다"),
 
-    // login
-    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해주세요.");
+    //로그인 & 로그아웃 검증
+    JWT_TIMEOUT(HttpStatus.BAD_REQUEST, "만료된 JWT 토큰입니다."),
+    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해주세요."),
+    NOT_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, "소셜 로그인 기능을 이용하세요");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/zerototen/savegame/repository/MemberRepository.java
+++ b/src/main/java/com/zerototen/savegame/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.zerototen.savegame.member.domain.repository;
+package com.zerototen.savegame.repository;
 
-import com.zerototen.savegame.member.domain.model.Member;
+import com.zerototen.savegame.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
-
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findOneWithAuthoritiesByEmail(String email);
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/zerototen/savegame/service/MemberService.java
+++ b/src/main/java/com/zerototen/savegame/service/MemberService.java
@@ -1,0 +1,164 @@
+package com.zerototen.savegame.service;
+
+import static com.zerototen.savegame.exception.ErrorCode.ALREADY_REGISTER_EMAIL;
+import static com.zerototen.savegame.exception.ErrorCode.LOGIN_CHECK_FAIL;
+import static com.zerototen.savegame.exception.ErrorCode.NOT_CONTAINS_EXCLAMATIONMARK;
+import static com.zerototen.savegame.exception.ErrorCode.NOT_EMAIL_FORM;
+import static com.zerototen.savegame.exception.ErrorCode.NOT_SOCIAL_LOGIN;
+import static com.zerototen.savegame.exception.ErrorCode.PASSWORD_SIZE_ERROR;
+import static com.zerototen.savegame.exception.ErrorCode.WANT_SOCIAL_REGISTER;
+import com.zerototen.savegame.config.Jwt.TokenProvider;
+import com.zerototen.savegame.dto.MemberDto;
+import com.zerototen.savegame.entity.Authority;
+import com.zerototen.savegame.entity.Member;
+import com.zerototen.savegame.exception.CustomException;
+import com.zerototen.savegame.repository.MemberRepository;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+
+    private static Set<Authority> getAuthorities() {
+        Authority authority = Authority.builder()
+            .authorityName("ROLE_MEMBER")
+            .build();
+        return Collections.singleton(authority);
+    }
+
+    // Service
+    // 회원가입
+    @Transactional
+    public ResponseEntity<MemberDto.SaveDto> register(MemberDto.SaveDto request) {
+        REGISTER_VALIDATION(request);
+        Member member = memberRepository.save(
+            Member.builder()
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .imageUrl(request.getUserImage())
+                .authorities(getAuthorities())
+                .build()
+        );
+
+        Authentication authentication = getAuthentication(request.getEmail(),
+            request.getPassword());
+        String accessToken = tokenProvider.createToken(authentication);
+        String refreshToken = tokenProvider.createRefreshToken(request.getEmail());
+
+        return new ResponseEntity<>(MemberDto.SaveDto.response(member, accessToken, refreshToken),
+            HttpStatus.OK);
+    }
+
+    //로그인
+    @Transactional
+    public ResponseEntity<MemberDto.LoginDto> login(MemberDto.LoginDto request) {
+        LOGIN_VALIDATE(request);
+
+        Authentication authentication = getAuthentication(request.getEmail(),
+            request.getPassword());
+        String accessToken = tokenProvider.createToken(authentication);
+        String refreshToken = tokenProvider.createRefreshToken(request.getEmail());
+
+        return new ResponseEntity<>(MemberDto.LoginDto.response(accessToken, refreshToken),
+            HttpStatus.OK);
+    }
+
+
+    private void LOGIN_VALIDATE(MemberDto.LoginDto request) {
+        memberRepository.findByEmail(request.getEmail())
+            .orElseThrow(
+                () -> new CustomException(LOGIN_CHECK_FAIL)
+            );
+
+        if (request.getEmail().contains("gmail")) {
+            throw new CustomException(NOT_SOCIAL_LOGIN);
+        }
+
+        //카카오 비활성화
+//    if (request.getEmail().contains("daum"))
+//      throw new CustomException(NOT_SOCIAL_LOGIN);
+
+        if (!passwordEncoder.matches(
+            request.getPassword(),
+            memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(
+                    () -> new CustomException(LOGIN_CHECK_FAIL)
+                ).getPassword())
+        ) {
+            throw new CustomException(LOGIN_CHECK_FAIL);
+        }
+    }
+
+    private void REGISTER_VALIDATION(MemberDto.SaveDto request) {
+/*        if (request.getEmail() == null || request.getPw() == null || request.getName() == null
+                || request.getWeight() == null || request.getHeight() == null)
+            throw new CustomException(REGISTER_INFO_NULL);*/
+        if (request.getEmail().contains("gmail") || request.getEmail().contains("daum")) {
+            throw new CustomException(WANT_SOCIAL_REGISTER);
+        }
+
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ALREADY_REGISTER_EMAIL);
+        }
+
+        if (!request.getEmail().contains("@")) {
+            throw new CustomException(NOT_EMAIL_FORM);
+        }
+
+        if (!(request.getPassword().length() > 5)) {
+            throw new CustomException(PASSWORD_SIZE_ERROR);
+        }
+
+        if (!(request.getPassword().contains("!") || request.getPassword().contains("@")
+            || request.getPassword().contains("#")
+            || request.getPassword().contains("$") || request.getPassword().contains("%")
+            || request.getPassword().contains("^")
+            || request.getPassword().contains("&") || request.getPassword().contains("*")
+            || request.getPassword().contains("(")
+            || request.getPassword().contains(")"))
+        ) {
+            throw new CustomException(NOT_CONTAINS_EXCLAMATIONMARK);
+        }
+    }
+
+    private Authentication getAuthentication(String request, String request1) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+            new UsernamePasswordAuthenticationToken(request, request1);
+        Authentication authentication = authenticationManagerBuilder.getObject()
+            .authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return authentication;
+    }
+
+    public boolean isEmailExist(String email) {
+        return memberRepository.findByEmail(email.toLowerCase(Locale.ROOT))
+            .isPresent();
+    }
+
+    public boolean isNicknameExist(String nickname) {
+        return memberRepository.findByNickname(nickname.toLowerCase(Locale.ROOT))
+            .isPresent();
+    }
+
+}

--- a/src/test/java/com/zerototen/savegame/service/MemberServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/MemberServiceTest.java
@@ -1,0 +1,136 @@
+package com.zerototen.savegame.service;
+
+import com.zerototen.savegame.dto.MemberDto;
+import com.zerototen.savegame.dto.MemberDto.LoginDto;
+import com.zerototen.savegame.dto.MemberDto.SaveDto;
+import com.zerototen.savegame.entity.Member;
+import com.zerototen.savegame.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class MemberServiceTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원가입")
+    void register() {
+
+        // given
+      MemberDto.SaveDto member = SaveDto.builder()
+          .nickname("challenger")
+          .email("challengers@challengers.com")
+          .password("password!")
+          .build();
+
+        // when
+        memberService.register(member);
+
+        //then
+        Member findMember = memberRepository.findByNickname("challenger").get();
+        Assertions.assertThat(member.getNickname()).isEqualTo(findMember.getNickname());
+
+    }
+
+    @Test
+    @DisplayName("로그인")
+    @Transactional
+    void login() {
+        // given
+        MemberDto.SaveDto member = SaveDto.builder()
+            .nickname("challenger1")
+            .email("challengers1@challengers.com")
+            .password("password!")
+            .build();
+        memberService.register(member);
+
+        // when
+        MemberDto.LoginDto loginMember = LoginDto.builder()
+            .email("challengers1@challengers.com")
+            .password("password!")
+            .build();
+
+        //then
+        Assertions.assertThat(memberService.login(loginMember).getStatusCodeValue()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("이메일 존재 할 때 True 반환")
+    @Transactional
+    void isEmailExist() {
+
+        // given
+        Member member = Member.builder()
+            .email("test@test.com")
+            .build();
+
+        // when
+        memberRepository.save(member);
+
+        // then
+        Assertions.assertThat(memberService.isEmailExist(member.getEmail())).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("이메일 존재하지 않을 때 False 반환")
+    @Transactional
+    void isEmailNotExist() {
+
+        // given
+        Member member = Member.builder()
+            .email("test@test.com")
+            .build();
+
+        // when
+        memberRepository.save(member);
+
+        // then
+        Assertions.assertThat(memberService.isEmailExist("fake@fake.com")).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("닉네임 존재할 때 True 반환")
+    @Transactional
+    void isNicknameExist() {
+
+        // given
+        Member member = Member.builder()
+            .nickname("nick")
+            .build();
+
+        // when
+        memberRepository.save(member);
+
+        // then
+        Assertions.assertThat(memberService.isNicknameExist(member.getNickname())).isTrue();
+    }
+
+    @Test
+    @DisplayName("닉네임 존재하지 않을 때 False 반환")
+    @Transactional
+    void isNicknameNotExist() {
+
+        // given
+        Member member = Member.builder()
+            .nickname("nick")
+            .build();
+
+        // when
+        memberRepository.save(member);
+
+        // then
+        Assertions.assertThat(memberService.isNicknameExist("name")).isFalse();
+    }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
회원 가입 및 로그인 기능 구현
ㄴ가입 시 비밀번호 규칙 등 검증 코드 구현(6글자 이상, 특수 문자 포함 등)
토큰, 리프래시 토큰 발행
보안 설정 구현
ㄴ 현재는 멤버 권한으로 기본 기능 사용 가능.
    추후 관리자 기능 추가로 챌린지 개설자 외에도 챌린지 강제 닫기 가능 등

**TO-BE**
단일 모듈화 리펙토링 실시
ㄴ 현재 기능 업로드 구현 먼저

OAuth2 테스트 코드 작성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

-- 실행된 테스트 코드
1. 회원 가입 테스트 : API에서 입력 받아 service 에서 save 를 호출한 후, 레포지토리에서 해당 회원을 찾을 수 있음.
2. 로그인 테스트 : 회원 가입을 한 후, 해당 아이디에 맞는 아이디 / 비밀번호로 로그인 하고나서 response code가 200인지 확인.
3. 이메일 존재 확인 : 존재 시 True, 부재 시 False 반환
4. 닉네임 존재 확인 : 존재 시 True 부재시 False 반환

