### PR TITLE
[refactor-requestheader-to-httpservletrequest] @RequestHeader를 HttpServletRequest로 변경

### DIFF
--- a/src/main/java/com/zerototen/savegame/controller/AuthController.java
+++ b/src/main/java/com/zerototen/savegame/controller/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/auth/login")
-    public ResponseDto<?> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+    public ResponseDto<String> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
         return authService.login(request, response);
     }
 
@@ -67,19 +67,19 @@ public class AuthController {
 
     // 이메일 중복 확인
     @GetMapping("/auth/checkemail")
-    public ResponseDto<?> checkDuplicationemail(@RequestBody @Valid DuplicationRequest requestDto) {
+    public ResponseDto<String> checkDuplicationemail(@RequestBody @Valid DuplicationRequest requestDto) {
         return authService.checkEmail(requestDto);
     }
 
     // 닉네임 중복 확인
     @GetMapping("/auth/checknickname")
-    public ResponseDto<?> checkDuplicationNickname(@RequestBody @Valid DuplicationRequest requestDto) {
+    public ResponseDto<String> checkDuplicationNickname(@RequestBody @Valid DuplicationRequest requestDto) {
         return authService.checkNickname(requestDto);
     }
 
     // 토큰 재발급
     @GetMapping("/auth/reissue")
-    public ResponseDto<?> getNewAccessToken(HttpServletRequest request, HttpServletResponse response)
+    public ResponseDto<String> getNewAccessToken(HttpServletRequest request, HttpServletResponse response)
         throws ParseException {
         return authService.reissue(request, response);
     }

--- a/src/main/java/com/zerototen/savegame/controller/AuthController.java
+++ b/src/main/java/com/zerototen/savegame/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.zerototen.savegame.domain.dto.request.DuplicationRequest;
 import com.zerototen.savegame.domain.dto.request.LoginRequest;
 import com.zerototen.savegame.domain.dto.request.SignupRequest;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
-import com.zerototen.savegame.security.TokenProvider;
 import com.zerototen.savegame.service.AuthService;
 import com.zerototen.savegame.service.KakaoOauthService;
 import javax.servlet.http.HttpServletRequest;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,10 +28,6 @@ public class AuthController {
 
     private final KakaoOauthService kakaoOauthService;
     private final AuthService authService;
-    private final TokenProvider tokenProvider;
-
-    private static final String ACCESS_TOKEN = "Authorization";
-    private static final String REFRESH_TOKEN = "refreshtoken";
 
     @GetMapping("/index")
     public String index() {
@@ -54,8 +48,8 @@ public class AuthController {
 
     // 로그아웃
     @PostMapping("/auth/logout")
-    public ResponseDto<?> logout(@RequestHeader(name = ACCESS_TOKEN) String accessToken) {
-        return authService.logout(accessToken);
+    public ResponseDto<?> logout(HttpServletRequest request) {
+        return authService.logout(request);
     }
 
     // 카카오 로그인
@@ -85,16 +79,15 @@ public class AuthController {
 
     // 토큰 재발급
     @GetMapping("/auth/reissue")
-    public ResponseDto<?> getNewAccessToken(@RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestHeader(name = REFRESH_TOKEN) String refreshToken, HttpServletResponse response)
+    public ResponseDto<?> getNewAccessToken(HttpServletRequest request, HttpServletResponse response)
         throws ParseException {
-        return authService.reissue(accessToken, refreshToken, response);
+        return authService.reissue(request, response);
     }
 
     // 회원 탈퇴
     @DeleteMapping("/auth/withdrawal")
-    public ResponseDto<?> withdrawal(@RequestHeader(name = ACCESS_TOKEN) String accessToken) {
-        return authService.withdrawal(tokenProvider.getMemberIdByToken(accessToken));
+    public ResponseDto<?> withdrawal(HttpServletRequest request) {
+        return authService.withdrawal(request);
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/controller/MemberController.java
+++ b/src/main/java/com/zerototen/savegame/controller/MemberController.java
@@ -4,15 +4,14 @@ import com.zerototen.savegame.domain.dto.request.UpdateNicknameRequest;
 import com.zerototen.savegame.domain.dto.request.UpdatePasswordRequest;
 import com.zerototen.savegame.domain.dto.request.UpdateProfileImageUrlRequest;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
-import com.zerototen.savegame.security.TokenProvider;
 import com.zerototen.savegame.service.MemberService;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,35 +22,32 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-    private final TokenProvider tokenProvider;
-
-    private static final String ACCESS_TOKEN = "Authorization";
 
     // 회원정보 조회
     @GetMapping("/detail")
-    public ResponseDto<?> getDetail(@RequestHeader(name = ACCESS_TOKEN) String accessToken) {
-        return memberService.getDetail(tokenProvider.getMemberIdByToken(accessToken));
+    public ResponseDto<?> getDetail(HttpServletRequest request) {
+        return memberService.getDetail(request);
     }
 
     // 비밀번호 수정
     @PutMapping("/detail/password")
-    public ResponseDto<?> updatePassword(@RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestBody @Valid UpdatePasswordRequest request) {
-        return memberService.updatePassword(tokenProvider.getMemberIdByToken(accessToken), request);
+    public ResponseDto<?> updatePassword(HttpServletRequest request,
+        @RequestBody @Valid UpdatePasswordRequest passwordRequest) {
+        return memberService.updatePassword(request, passwordRequest);
     }
 
     // 닉네임 수정
     @PutMapping("/detail/nickname")
-    public ResponseDto<?> updateNickname(@RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestBody @Valid UpdateNicknameRequest request) {
-        return memberService.updateNickname(tokenProvider.getMemberIdByToken(accessToken), request);
+    public ResponseDto<?> updateNickname(HttpServletRequest request,
+        @RequestBody @Valid UpdateNicknameRequest nicknameRequest) {
+        return memberService.updateNickname(request, nicknameRequest);
     }
 
     // 프로필 이미지 수정
     @PutMapping("/detail/image")
-    public ResponseDto<?> updateProfileImageUrl(@RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestBody UpdateProfileImageUrlRequest request) {
-        return memberService.updateProfileImageUrl(tokenProvider.getMemberIdByToken(accessToken), request);
+    public ResponseDto<?> updateProfileImageUrl(HttpServletRequest request,
+        @RequestBody UpdateProfileImageUrlRequest imageUrlRequest) {
+        return memberService.updateProfileImageUrl(request, imageUrlRequest);
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/controller/RecordController.java
+++ b/src/main/java/com/zerototen/savegame/controller/RecordController.java
@@ -1,5 +1,7 @@
 package com.zerototen.savegame.controller;
 
+import com.zerototen.savegame.domain.dto.CreateRecordServiceDto;
+import com.zerototen.savegame.domain.dto.UpdateRecordServiceDto;
 import com.zerototen.savegame.domain.dto.request.CreateRecordRequest;
 import com.zerototen.savegame.domain.dto.request.UpdateRecordRequest;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
@@ -35,7 +37,7 @@ public class RecordController {
     @PostMapping
     public ResponseDto<?> createRecord(
         HttpServletRequest request, @RequestBody @Valid CreateRecordRequest createRecordRequest) {
-        return recordService.create(request, createRecordRequest.toServiceDto());
+        return recordService.create(request, CreateRecordServiceDto.from(createRecordRequest));
     }
 
     @GetMapping
@@ -56,7 +58,7 @@ public class RecordController {
     public ResponseDto<?> updateRecord(
         HttpServletRequest request, @PathVariable Long recordId,
         @RequestBody @Valid UpdateRecordRequest updateRecordRequest) {
-        return recordService.update(request, updateRecordRequest.toServiceDto(recordId));
+        return recordService.update(request, UpdateRecordServiceDto.from(recordId, updateRecordRequest));
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/zerototen/savegame/controller/RecordController.java
+++ b/src/main/java/com/zerototen/savegame/controller/RecordController.java
@@ -4,11 +4,11 @@ import com.zerototen.savegame.domain.dto.request.CreateRecordRequest;
 import com.zerototen.savegame.domain.dto.request.UpdateRecordRequest;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
 import com.zerototen.savegame.domain.type.Category;
-import com.zerototen.savegame.security.TokenProvider;
 import com.zerototen.savegame.service.RecordService;
 import com.zerototen.savegame.validation.EnumList;
 import java.time.LocalDate;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,45 +31,37 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecordController {
 
     private final RecordService recordService;
-    private final TokenProvider tokenProvider;
-    private static final String ACCESS_TOKEN = "Authorization";
 
     @PostMapping
     public ResponseDto<?> createRecord(
-        @RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestBody @Valid CreateRecordRequest request) {
-        return recordService.create(request.toServiceDto(tokenProvider.getMemberIdByToken(accessToken)));
+        HttpServletRequest request, @RequestBody @Valid CreateRecordRequest createRecordRequest) {
+        return recordService.create(request, createRecordRequest.toServiceDto());
     }
 
     @GetMapping
     public ResponseDto<?> getInfos(
-        @RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestParam LocalDate startDate, @RequestParam LocalDate endDate,
+        HttpServletRequest request, @RequestParam LocalDate startDate, @RequestParam LocalDate endDate,
         @RequestParam(required = false) @Validated @EnumList(enumClass = Category.class, ignoreCase = true)
         List<String> categories) {
-        return recordService.getInfos(tokenProvider.getMemberIdByToken(accessToken), startDate, endDate, categories);
+        return recordService.getInfos(request, startDate, endDate, categories);
     }
 
     @GetMapping("/analysis")
     public ResponseDto<?> getAnalysisInfo(
-        @RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @RequestParam int year, @RequestParam @Valid @Min(1) @Max(12) int month) {
-        return recordService.getAnalysisInfo(tokenProvider.getMemberIdByToken(accessToken), year, month);
+        HttpServletRequest request, @RequestParam int year, @RequestParam @Valid @Min(1) @Max(12) int month) {
+        return recordService.getAnalysisInfo(request, year, month);
     }
 
     @PutMapping("/{recordId}")
     public ResponseDto<?> updateRecord(
-        @RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @PathVariable Long recordId,
-        @RequestBody @Valid UpdateRecordRequest request) {
-        return recordService.update(request.toServiceDto(recordId, tokenProvider.getMemberIdByToken(accessToken)));
+        HttpServletRequest request, @PathVariable Long recordId,
+        @RequestBody @Valid UpdateRecordRequest updateRecordRequest) {
+        return recordService.update(request, updateRecordRequest.toServiceDto(recordId));
     }
 
     @DeleteMapping("/{recordId}")
-    public ResponseDto<?> deleteRecord(
-        @RequestHeader(name = ACCESS_TOKEN) String accessToken,
-        @PathVariable Long recordId) {
-        return recordService.delete(recordId, tokenProvider.getMemberIdByToken(accessToken));
+    public ResponseDto<?> deleteRecord(HttpServletRequest request, @PathVariable Long recordId) {
+        return recordService.delete(request, recordId);
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/CreateRecordServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/CreateRecordServiceDto.java
@@ -1,9 +1,12 @@
 package com.zerototen.savegame.domain.dto;
 
+import com.zerototen.savegame.domain.dto.request.CreateRecordRequest;
 import com.zerototen.savegame.domain.entity.Record;
 import com.zerototen.savegame.domain.type.Category;
 import com.zerototen.savegame.domain.type.PayType;
+import com.zerototen.savegame.util.ConvertUtil;
 import java.time.LocalDate;
+import java.util.Locale;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,15 +25,14 @@ public class CreateRecordServiceDto {
     private LocalDate useDate;
     private PayType payType;
 
-    public Record toEntity(Long memberId) {
-        return Record.builder()
-            .memberId(memberId)
-            .amount(this.getAmount())
-            .category(this.getCategory())
-            .paidFor(this.getPaidFor())
-            .useDate(this.getUseDate())
-            .payType(this.getPayType())
-            .memo(this.getMemo())
+    public static CreateRecordServiceDto from(CreateRecordRequest request) {
+        return CreateRecordServiceDto.builder()
+            .amount(request.getAmount())
+            .category(Category.valueOf(request.getCategory().toUpperCase(Locale.ROOT)))
+            .paidFor(request.getPaidFor())
+            .useDate(ConvertUtil.stringToLocalDate(request.getUseDate()))
+            .payType(PayType.valueOf(request.getPayType().toUpperCase(Locale.ROOT)))
+            .memo(request.getMemo())
             .build();
     }
 

--- a/src/main/java/com/zerototen/savegame/domain/dto/CreateRecordServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/CreateRecordServiceDto.java
@@ -1,7 +1,6 @@
 package com.zerototen.savegame.domain.dto;
 
 import com.zerototen.savegame.domain.dto.request.CreateRecordRequest;
-import com.zerototen.savegame.domain.entity.Record;
 import com.zerototen.savegame.domain.type.Category;
 import com.zerototen.savegame.domain.type.PayType;
 import com.zerototen.savegame.util.ConvertUtil;

--- a/src/main/java/com/zerototen/savegame/domain/dto/CreateRecordServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/CreateRecordServiceDto.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateRecordServiceDto {
 
-    private Long memberId;
     private int amount;
     private Category category;
     private String paidFor;
@@ -23,9 +22,9 @@ public class CreateRecordServiceDto {
     private LocalDate useDate;
     private PayType payType;
 
-    public Record toEntity() {
+    public Record toEntity(Long memberId) {
         return Record.builder()
-            .memberId(this.getMemberId())
+            .memberId(memberId)
             .amount(this.getAmount())
             .category(this.getCategory())
             .paidFor(this.getPaidFor())

--- a/src/main/java/com/zerototen/savegame/domain/dto/RecordAnalysisServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/RecordAnalysisServiceDto.java
@@ -18,11 +18,4 @@ public class RecordAnalysisServiceDto {
     private Category category;
     private Long total;
 
-    public RecordAnalysisResponse toResponse() {
-        return RecordAnalysisResponse.builder()
-            .category(this.getCategory().getName())
-            .total(this.getTotal())
-            .build();
-    }
-
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/RecordAnalysisServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/RecordAnalysisServiceDto.java
@@ -1,6 +1,5 @@
 package com.zerototen.savegame.domain.dto;
 
-import com.zerototen.savegame.domain.dto.response.RecordAnalysisResponse;
 import com.zerototen.savegame.domain.type.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/zerototen/savegame/domain/dto/UpdateRecordServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/UpdateRecordServiceDto.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 public class UpdateRecordServiceDto {
 
     private Long id;
-    private Long memberId;
     private int amount;
     private Category category;
     private String paidFor;

--- a/src/main/java/com/zerototen/savegame/domain/dto/UpdateRecordServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/UpdateRecordServiceDto.java
@@ -1,8 +1,11 @@
 package com.zerototen.savegame.domain.dto;
 
+import com.zerototen.savegame.domain.dto.request.UpdateRecordRequest;
 import com.zerototen.savegame.domain.type.Category;
 import com.zerototen.savegame.domain.type.PayType;
+import com.zerototen.savegame.util.ConvertUtil;
 import java.time.LocalDate;
+import java.util.Locale;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,5 +24,17 @@ public class UpdateRecordServiceDto {
     private String memo;
     private LocalDate useDate;
     private PayType payType;
+
+    public static UpdateRecordServiceDto from(Long recordId, UpdateRecordRequest request) {
+        return UpdateRecordServiceDto.builder()
+            .id(recordId)
+            .amount(request.getAmount())
+            .category(Category.valueOf(request.getCategory().toUpperCase(Locale.ROOT)))
+            .paidFor(request.getPaidFor())
+            .useDate(ConvertUtil.stringToLocalDate(request.getUseDate()))
+            .payType(PayType.valueOf(request.getPayType().toUpperCase(Locale.ROOT)))
+            .memo(request.getMemo())
+            .build();
+    }
 
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/CreateRecordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/CreateRecordRequest.java
@@ -37,9 +37,8 @@ public class CreateRecordRequest {
     @Enum(enumClass = PayType.class, ignoreCase = true)
     private String payType;
 
-    public CreateRecordServiceDto toServiceDto(Long memberId) {
+    public CreateRecordServiceDto toServiceDto() {
         return CreateRecordServiceDto.builder()
-            .memberId(memberId)
             .amount(this.getAmount())
             .category(Category.valueOf(this.getCategory().toUpperCase(Locale.ROOT)))
             .paidFor(this.getPaidFor())

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/CreateRecordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/CreateRecordRequest.java
@@ -1,11 +1,8 @@
 package com.zerototen.savegame.domain.dto.request;
 
-import com.zerototen.savegame.domain.dto.CreateRecordServiceDto;
 import com.zerototen.savegame.domain.type.Category;
 import com.zerototen.savegame.domain.type.PayType;
-import com.zerototen.savegame.util.ConvertUtil;
 import com.zerototen.savegame.validation.Enum;
-import java.util.Locale;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/CreateRecordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/CreateRecordRequest.java
@@ -37,15 +37,4 @@ public class CreateRecordRequest {
     @Enum(enumClass = PayType.class, ignoreCase = true)
     private String payType;
 
-    public CreateRecordServiceDto toServiceDto() {
-        return CreateRecordServiceDto.builder()
-            .amount(this.getAmount())
-            .category(Category.valueOf(this.getCategory().toUpperCase(Locale.ROOT)))
-            .paidFor(this.getPaidFor())
-            .useDate(ConvertUtil.stringToLocalDate(this.getUseDate()))
-            .payType(PayType.valueOf(this.getPayType().toUpperCase(Locale.ROOT)))
-            .memo(this.getMemo())
-            .build();
-    }
-
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/UpdatePasswordRequest.java
@@ -21,8 +21,4 @@ public class UpdatePasswordRequest {
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String newPassword;
 
-    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
-    private String newPasswordCheck;
-
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/UpdateRecordRequest.java
@@ -37,16 +37,4 @@ public class UpdateRecordRequest {
     @Enum(enumClass = PayType.class, ignoreCase = true)
     private String payType;
 
-    public UpdateRecordServiceDto toServiceDto(Long recordId) {
-        return UpdateRecordServiceDto.builder()
-            .id(recordId)
-            .amount(this.getAmount())
-            .category(Category.valueOf(this.getCategory().toUpperCase(Locale.ROOT)))
-            .paidFor(this.getPaidFor())
-            .useDate(ConvertUtil.stringToLocalDate(this.getUseDate()))
-            .payType(PayType.valueOf(this.getPayType().toUpperCase(Locale.ROOT)))
-            .memo(this.getMemo())
-            .build();
-    }
-
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/UpdateRecordRequest.java
@@ -37,10 +37,9 @@ public class UpdateRecordRequest {
     @Enum(enumClass = PayType.class, ignoreCase = true)
     private String payType;
 
-    public UpdateRecordServiceDto toServiceDto(Long id, Long memberId) {
+    public UpdateRecordServiceDto toServiceDto(Long recordId) {
         return UpdateRecordServiceDto.builder()
-            .id(id)
-            .memberId(memberId)
+            .id(recordId)
             .amount(this.getAmount())
             .category(Category.valueOf(this.getCategory().toUpperCase(Locale.ROOT)))
             .paidFor(this.getPaidFor())

--- a/src/main/java/com/zerototen/savegame/domain/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/request/UpdateRecordRequest.java
@@ -1,11 +1,8 @@
 package com.zerototen.savegame.domain.dto.request;
 
-import com.zerototen.savegame.domain.dto.UpdateRecordServiceDto;
 import com.zerototen.savegame.domain.type.Category;
 import com.zerototen.savegame.domain.type.PayType;
-import com.zerototen.savegame.util.ConvertUtil;
 import com.zerototen.savegame.validation.Enum;
-import java.util.Locale;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;

--- a/src/main/java/com/zerototen/savegame/domain/dto/response/MemberResponse.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/response/MemberResponse.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberResponse {
 
+    private Long memberId;
     private String email;
     private String nickname;
     private String password;
@@ -19,9 +20,10 @@ public class MemberResponse {
 
     public static MemberResponse from(Member member) {
         return MemberResponse.builder()
+            .memberId(member.getId())
             .email(member.getEmail())
             .nickname(member.getNickname())
-            .password("*".repeat(8)) // TODO: 원래 비밀번호 길이를 구할수 없으므로 일단 *만 8자리 보냄, 다른방법 있는지 확인
+            .password("********")
             .profileImageUrl(member.getProfileImageUrl())
             .build();
     }

--- a/src/main/java/com/zerototen/savegame/domain/dto/response/RecordAnalysisResponse.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/response/RecordAnalysisResponse.java
@@ -1,5 +1,6 @@
 package com.zerototen.savegame.domain.dto.response;
 
+import com.zerototen.savegame.domain.dto.RecordAnalysisServiceDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,5 +14,12 @@ public class RecordAnalysisResponse {
 
     private String category;
     private long total;
+
+    public static RecordAnalysisResponse from(RecordAnalysisServiceDto serviceDto) {
+        return RecordAnalysisResponse.builder()
+            .category(serviceDto.getCategory().getName())
+            .total(serviceDto.getTotal())
+            .build();
+    }
 
 }

--- a/src/main/java/com/zerototen/savegame/domain/entity/BlacklistToken.java
+++ b/src/main/java/com/zerototen/savegame/domain/entity/BlacklistToken.java
@@ -1,0 +1,23 @@
+package com.zerototen.savegame.domain.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class BlacklistToken {
+
+    @Id
+    private String keyValue;
+
+    private LocalDateTime expiredDateTime;
+
+}

--- a/src/main/java/com/zerototen/savegame/domain/entity/Record.java
+++ b/src/main/java/com/zerototen/savegame/domain/entity/Record.java
@@ -1,5 +1,6 @@
 package com.zerototen.savegame.domain.entity;
 
+import com.zerototen.savegame.domain.dto.CreateRecordServiceDto;
 import com.zerototen.savegame.domain.dto.UpdateRecordServiceDto;
 import com.zerototen.savegame.domain.type.Category;
 import com.zerototen.savegame.domain.type.PayType;
@@ -57,6 +58,18 @@ public class Record {
         this.memo = serviceDto.getMemo();
         this.useDate = serviceDto.getUseDate();
         this.payType = serviceDto.getPayType();
+    }
+
+    public static Record from(Long memberId, CreateRecordServiceDto serviceDto) {
+        return Record.builder()
+            .memberId(memberId)
+            .amount(serviceDto.getAmount())
+            .category(serviceDto.getCategory())
+            .paidFor(serviceDto.getPaidFor())
+            .useDate(serviceDto.getUseDate())
+            .payType(serviceDto.getPayType())
+            .memo(serviceDto.getMemo())
+            .build();
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/repository/BlacklistTokenRepository.java
+++ b/src/main/java/com/zerototen/savegame/repository/BlacklistTokenRepository.java
@@ -1,0 +1,10 @@
+package com.zerototen.savegame.repository;
+
+import com.zerototen.savegame.domain.entity.BlacklistToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlacklistTokenRepository extends JpaRepository<BlacklistToken, String> {
+
+}

--- a/src/main/java/com/zerototen/savegame/security/TokenProvider.java
+++ b/src/main/java/com/zerototen/savegame/security/TokenProvider.java
@@ -139,7 +139,7 @@ public class TokenProvider {
         return true;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean checkBlacklistToken(String accessToken) {
         return blacklistTokenRepository.existsById(accessToken);
     }
@@ -217,18 +217,20 @@ public class TokenProvider {
             return null;
         }
 
-        if (checkBlacklistToken(request.getHeader("Authorization"))) {
+        if (checkBlacklistToken(getAccessToken(request))) {
             return null;
         }
 
         Member member = getMemberFromAuthentication();
-        if (!isPresentRefreshToken(member).getKeyValue().equals(refreshTokenOfHeader)) {
+        if (isPresentRefreshToken(member) == null || !isPresentRefreshToken(member).getKeyValue()
+            .equals(refreshTokenOfHeader)) {
             return null;
         }
 
         return member;
     }
 
+    @Transactional
     public ResponseDto<?> validateCheck(HttpServletRequest request) {
         // RefreshToken 및 Authorization 유효성 검사
         if (null == request.getHeader("RefreshToken") || null == request.getHeader("Authorization")) {

--- a/src/main/java/com/zerototen/savegame/service/AuthService.java
+++ b/src/main/java/com/zerototen/savegame/service/AuthService.java
@@ -14,6 +14,7 @@ import com.zerototen.savegame.security.TokenProvider;
 import com.zerototen.savegame.util.PasswordUtil;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ public class AuthService {
     private final TokenProvider tokenProvider;
 
     @Value("${image.default.profile}")
-    private String defaultImageUrl; // TODO: 기본 이미지 URL 경로 프론트에 물어보기
+    private String defaultImageUrl; // TODO: 기본 이미지 URL 경로설정
 
     // 회원가입
     @Transactional
@@ -90,21 +91,19 @@ public class AuthService {
 
     // 로그아웃
     @Transactional
-    public ResponseDto<?> logout(String accessToken) {
-        if (!tokenProvider.validateToken(accessToken)) {
-            return ResponseDto.fail("토큰 값이 올바르지 않습니다.");
+    public ResponseDto<?> logout(HttpServletRequest request) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
 
-        // 맴버객체 찾아오기
-        Member member = tokenProvider.getMemberFromAuthentication();
-        if (null == member) {
-            return ResponseDto.fail("사용자를 찾을 수 없습니다.");
-        }
+        Member member = (Member) responseDto.getData();
+
         if (tokenProvider.deleteRefreshToken(member)) {
             return ResponseDto.fail("존재하지 않는 Token 입니다.");
         }
 
-        tokenProvider.deleteRefreshToken(member);
+        tokenProvider.deleteRefreshToken(member); // TODO: 필요한가?
 
         return ResponseDto.success("로그아웃 성공");
     }
@@ -143,51 +142,54 @@ public class AuthService {
 
     // refresh token 재발급
     @Transactional
-    public ResponseDto<?> reissue(String accessToken, String refreshToken, HttpServletResponse response)
-        throws ParseException {
-        if (tokenProvider.getMemberIdByToken(accessToken) != null) {
+    public ResponseDto<?> reissue(HttpServletRequest request, HttpServletResponse response) throws ParseException {
+        if (tokenProvider.getMemberIdByToken(request.getHeader("Authorization")) != null) {
             return ResponseDto.fail("아직 유효한 access token 입니다.");
         }
-        if (!tokenProvider.validateToken(refreshToken)) {
+        if (!tokenProvider.validateToken(request.getHeader("RefreshToken"))) {
             return ResponseDto.fail("유효하지 않은 refresh token입니다.");
         }
-        String memberId = tokenProvider.getMemberFromExpiredAccessToken(accessToken);
+        String memberId = tokenProvider.getMemberFromExpiredAccessToken(request);
         if (null == memberId) {
             return ResponseDto.fail("access token의 값이 유효하지 않습니다.");
         }
         Member member = memberRepository.findById(Long.parseLong(memberId)).orElse(null);
 
-        RefreshToken refreshTokenDB = tokenProvider.isPresentRefreshToken(member);
+        RefreshToken refreshToken = tokenProvider.isPresentRefreshToken(member);
 
-        if (!refreshTokenDB.getKeyValue().equals(refreshToken)) {
-            log.info("refreshToken : " + refreshTokenDB.getKeyValue());
-            log.info("header rft : " + refreshToken);
+        if (!refreshToken.getKeyValue().equals(request.getHeader("RefreshToken"))) {
+            log.info("refreshToken : " + refreshToken.getKeyValue());
+            log.info("header rft : " + request.getHeader("RefreshToken"));
             return ResponseDto.fail("토큰이 일치하지 않습니다.");
         }
 
         TokenDto tokenDto = tokenProvider.generateTokenDto(member);
-        refreshTokenDB.updateValue(tokenDto.getRefreshToken());
+        refreshToken.updateValue(tokenDto.getRefreshToken());
         tokenToHeaders(tokenDto, response);
 
         return ResponseDto.success("재발급 완료");
     }
 
     @Transactional
-    public ResponseDto<?> withdrawal(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElse(null);
-
-        if (member == null) {
-            return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+    public ResponseDto<?> withdrawal(HttpServletRequest request) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
+
+        Member member = (Member) responseDto.getData();
 
         if (member.getDeletedAt() != null) {
             return ResponseDto.fail("이미 탈퇴한 사용자입니다.");
         }
 
-        tokenProvider.deleteRefreshToken(member);
+        if (tokenProvider.deleteRefreshToken(member)) {
+            return ResponseDto.fail("존재하지 않는 Token 입니다.");
+        }
+
         memberRepository.delete(member);
 
-        log.debug("Withdraw member -> memberId: {}", memberId);
+        log.debug("Withdraw member -> memberId: {}", member.getId());
         return ResponseDto.success("Delete Success");
     }
 

--- a/src/main/java/com/zerototen/savegame/service/AuthService.java
+++ b/src/main/java/com/zerototen/savegame/service/AuthService.java
@@ -60,7 +60,7 @@ public class AuthService {
 
     // 로그인
     @Transactional
-    public ResponseDto<?> login(LoginRequest request, HttpServletResponse response) {
+    public ResponseDto<String> login(LoginRequest request, HttpServletResponse response) {
         Member member = getMemberByEmail(request.getEmail());
         if (member == null) {
             return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
@@ -108,7 +108,7 @@ public class AuthService {
 
     // 이메일 중복 검사
     @Transactional(readOnly = true)
-    public ResponseDto<?> checkEmail(DuplicationRequest request) {
+    public ResponseDto<String> checkEmail(DuplicationRequest request) {
         String regExp = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$";
         if (!Pattern.matches(regExp, request.getValue())) {
             return ResponseDto.fail("이메일 양식을 지켜주세요.");
@@ -124,7 +124,7 @@ public class AuthService {
 
     // 닉네임 중복 검사
     @Transactional(readOnly = true)
-    public ResponseDto<?> checkNickname(DuplicationRequest request) {
+    public ResponseDto<String> checkNickname(DuplicationRequest request) {
         String regExp = "^[가-힣a-zA-Z0-9]{2,10}$";
         if (!Pattern.matches(regExp, request.getValue())) {
             return ResponseDto.fail("2~10자리 한글,대소문자,숫자만 입력해주세요.");
@@ -140,7 +140,7 @@ public class AuthService {
 
     // refresh token 재발급
     @Transactional
-    public ResponseDto<?> reissue(HttpServletRequest request, HttpServletResponse response) throws ParseException {
+    public ResponseDto<String> reissue(HttpServletRequest request, HttpServletResponse response) throws ParseException {
         if (tokenProvider.getMemberIdByToken(request.getHeader("Authorization")) != null) {
             return ResponseDto.fail("아직 유효한 access token 입니다.");
         }

--- a/src/main/java/com/zerototen/savegame/service/MemberService.java
+++ b/src/main/java/com/zerototen/savegame/service/MemberService.java
@@ -6,8 +6,9 @@ import com.zerototen.savegame.domain.dto.request.UpdateProfileImageUrlRequest;
 import com.zerototen.savegame.domain.dto.response.MemberResponse;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
 import com.zerototen.savegame.domain.entity.Member;
-import com.zerototen.savegame.exception.ErrorCode;
 import com.zerototen.savegame.repository.MemberRepository;
+import com.zerototen.savegame.security.TokenProvider;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,68 +21,78 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
 
     // 회원정보 조회
-    public ResponseDto<?> getDetail(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElse(null);
-        if (member == null) {
-            return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+    public ResponseDto<?> getDetail(HttpServletRequest request) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
+
+        Member member = (Member) responseDto.getData();
 
         return ResponseDto.success(MemberResponse.from(member));
     }
 
     // 비밀번호 수정
     @Transactional
-    public ResponseDto<?> updatePassword(Long memberId, UpdatePasswordRequest request) {
-        Member member = memberRepository.findById(memberId).orElse(null);
-        if (member == null) {
-            return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+    public ResponseDto<?> updatePassword(HttpServletRequest request, UpdatePasswordRequest passwordRequest) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
 
-        if (!request.getNewPassword().equals(request.getNewPasswordCheck())) {
+        Member member = (Member) responseDto.getData();
+
+        if (!passwordRequest.getNewPassword().equals(passwordRequest.getNewPasswordCheck())) {
             return ResponseDto.fail("비밀번호가 일치하지 않습니다.");
         }
 
-        if (!(new BCryptPasswordEncoder().matches(request.getOldPassword(), member.getPassword()))) {
+        if (!(new BCryptPasswordEncoder().matches(passwordRequest.getOldPassword(), member.getPassword()))) {
             return ResponseDto.fail("이전 비밀번호가 일치하지 않습니다.");
         }
 
-        member.updatePassword(request);
-
-        log.debug("Update password -> memberId: {}", memberId);
+        member.updatePassword(passwordRequest);
+        memberRepository.save(member);
+        log.debug("Update password -> memberId: {}", member.getId());
         return ResponseDto.success("Update Password Success");
     }
 
     // 닉네임 수정
     @Transactional
-    public ResponseDto<?> updateNickname(Long memberId, UpdateNicknameRequest request) {
-        Member member = memberRepository.findById(memberId).orElse(null);
-        if (member == null) {
-            return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+    public ResponseDto<?> updateNickname(HttpServletRequest request, UpdateNicknameRequest nicknameRequest) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
 
-        if (memberRepository.findByNickname(request.getNickname()).isPresent()) {
+        Member member = (Member) responseDto.getData();
+
+        if (memberRepository.findByNickname(nicknameRequest.getNickname()).isPresent()) {
             return ResponseDto.fail("중복된 닉네임 입니다.");
         }
 
-        member.updateNickname(request);
-
-        log.debug("Update nickname -> memberId: {}", memberId);
+        member.updateNickname(nicknameRequest);
+        memberRepository.save(member);
+        log.debug("Update nickname -> memberId: {}", member.getId());
         return ResponseDto.success("Update Nickname Success");
     }
 
     // 회원 이미지 수정
     @Transactional
-    public ResponseDto<?> updateProfileImageUrl(Long memberId, UpdateProfileImageUrlRequest request) {
-        Member member = memberRepository.findById(memberId).orElse(null);
-        if (member == null) {
-            return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+    public ResponseDto<?> updateProfileImageUrl(HttpServletRequest request,
+        UpdateProfileImageUrlRequest imageUrlRequest) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
 
-        member.updateProfileImageUrl(request);
+        Member member = (Member) responseDto.getData();
 
-        log.debug("Update profile image url -> memberId: {}", memberId);
+        member.updateProfileImageUrl(imageUrlRequest);
+        memberRepository.save(member);
+        log.debug("Update profile image url -> memberId: {}", member.getId());
         return ResponseDto.success("Update Profile Image Success");
     }
 

--- a/src/main/java/com/zerototen/savegame/service/MemberService.java
+++ b/src/main/java/com/zerototen/savegame/service/MemberService.java
@@ -45,10 +45,6 @@ public class MemberService {
 
         Member member = (Member) responseDto.getData();
 
-        if (!passwordRequest.getNewPassword().equals(passwordRequest.getNewPasswordCheck())) {
-            return ResponseDto.fail("비밀번호가 일치하지 않습니다.");
-        }
-
         if (!(new BCryptPasswordEncoder().matches(passwordRequest.getOldPassword(), member.getPassword()))) {
             return ResponseDto.fail("이전 비밀번호가 일치하지 않습니다.");
         }

--- a/src/main/java/com/zerototen/savegame/service/RecordService.java
+++ b/src/main/java/com/zerototen/savegame/service/RecordService.java
@@ -40,7 +40,7 @@ public class RecordService {
         Member member = (Member) responseDto.getData();
 
         log.debug("Create record -> memberId: {}", member.getId());
-        return ResponseDto.success(recordRepository.save(serviceDto.toEntity(member.getId())));
+        return ResponseDto.success(recordRepository.save(Record.from(member.getId(), serviceDto)));
     }
 
     // 지출 내역 조회 (가계부 메인)
@@ -86,7 +86,7 @@ public class RecordService {
             if (serviceDto.getTotal() == null || serviceDto.getTotal() <= 0) {
                 return ResponseDto.fail(ErrorCode.INVALID_TOTAL.getDetail());
             }
-            responses.add(serviceDto.toResponse());
+            responses.add(RecordAnalysisResponse.from(serviceDto));
         }
 
         return ResponseDto.success(responses);

--- a/src/main/java/com/zerototen/savegame/service/RecordService.java
+++ b/src/main/java/com/zerototen/savegame/service/RecordService.java
@@ -9,12 +9,13 @@ import com.zerototen.savegame.domain.dto.response.ResponseDto;
 import com.zerototen.savegame.domain.entity.Member;
 import com.zerototen.savegame.domain.entity.Record;
 import com.zerototen.savegame.exception.ErrorCode;
-import com.zerototen.savegame.repository.MemberRepository;
 import com.zerototen.savegame.repository.RecordRepository;
+import com.zerototen.savegame.security.TokenProvider;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,40 +26,56 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RecordService {
 
-    private final MemberRepository memberRepository;
     private final RecordRepository recordRepository;
+    private final TokenProvider tokenProvider;
 
     // 지출 내역 등록
     @Transactional
-    public ResponseDto<?> create(CreateRecordServiceDto serviceDto) {
-        Member member = memberRepository.findById(serviceDto.getMemberId()).orElse(null);
-        if (member == null) {
-            return ResponseDto.fail(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+    public ResponseDto<?> create(HttpServletRequest request, CreateRecordServiceDto serviceDto) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
         }
 
-        log.debug("Create record -> memberId: {}", serviceDto.getMemberId());
-        return ResponseDto.success(recordRepository.save(serviceDto.toEntity()));
+        Member member = (Member) responseDto.getData();
+
+        log.debug("Create record -> memberId: {}", member.getId());
+        return ResponseDto.success(recordRepository.save(serviceDto.toEntity(member.getId())));
     }
 
     // 지출 내역 조회 (가계부 메인)
-    public ResponseDto<?> getInfos(Long memberId, LocalDate startDate, LocalDate endDate,
+    public ResponseDto<?> getInfos(HttpServletRequest request, LocalDate startDate, LocalDate endDate,
         List<String> categories) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
+        }
+
+        Member member = (Member) responseDto.getData();
+
         if (startDate.isAfter(endDate)) {
             return ResponseDto.fail(ErrorCode.STARTDATE_AFTER_ENDDATE.getDetail());
         }
         List<Record> records = recordRepository.findByMemberIdAndUseDateDescWithOptional(
-            memberId, startDate, endDate, categories);
+            member.getId(), startDate, endDate, categories);
 
         return ResponseDto.success(records.stream().map(RecordResponse::from).collect(Collectors.toList()));
     }
 
     // 지출 내역 분석 (가계부 분석)
-    public ResponseDto<?> getAnalysisInfo(Long memberId, int year, int month) {
+    public ResponseDto<?> getAnalysisInfo(HttpServletRequest request, int year, int month) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
+        }
+
+        Member member = (Member) responseDto.getData();
+
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        List<RecordAnalysisServiceDto> serviceDtos = recordRepository.findByMemberIdAndUseDateAndAmountSumDesc(memberId,
-            startDate, endDate);
+        List<RecordAnalysisServiceDto> serviceDtos = recordRepository.findByMemberIdAndUseDateAndAmountSumDesc(
+            member.getId(), startDate, endDate);
 
         List<RecordAnalysisResponse> responses = new ArrayList<>();
 
@@ -77,13 +94,20 @@ public class RecordService {
 
     // 지출 내역 수정
     @Transactional
-    public ResponseDto<?> update(UpdateRecordServiceDto serviceDto) {
+    public ResponseDto<?> update(HttpServletRequest request, UpdateRecordServiceDto serviceDto) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
+        }
+
+        Member member = (Member) responseDto.getData();
+
         Record record = recordRepository.findById(serviceDto.getId()).orElse(null);
         if (record == null) {
             return ResponseDto.fail(ErrorCode.NOT_FOUND_RECORD.getDetail());
         }
 
-        if (!record.getMemberId().equals(serviceDto.getMemberId())) {
+        if (!validateAuthority(record, member)) {
             return ResponseDto.fail(ErrorCode.NOT_MATCH_MEMBER.getDetail());
         }
 
@@ -94,19 +118,30 @@ public class RecordService {
 
     // 지출 내역 삭제
     @Transactional
-    public ResponseDto<?> delete(Long id, Long memberId) {
-        Record record = recordRepository.findById(id).orElse(null);
+    public ResponseDto<?> delete(HttpServletRequest request, Long recordId) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
+        }
+
+        Member member = (Member) responseDto.getData();
+
+        Record record = recordRepository.findById(recordId).orElse(null);
         if (record == null) {
             return ResponseDto.fail(ErrorCode.NOT_FOUND_RECORD.getDetail());
         }
 
-        if (!record.getMemberId().equals(memberId)) {
+        if (!validateAuthority(record, member)) {
             return ResponseDto.fail(ErrorCode.NOT_MATCH_MEMBER.getDetail());
         }
 
         recordRepository.delete(record);
-        log.debug("Delete record -> id: {}", id);
+        log.debug("Delete record -> id: {}", recordId);
         return ResponseDto.success("Delete Success");
+    }
+
+    private boolean validateAuthority(Record record, Member member) {
+        return record.getMemberId().equals(member.getId());
     }
 
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,7 +27,3 @@ jwt:
 
 kakao:
   rest-api-key: ${KAKAO_RESTAPIKEY}
-
-image:
-  default:
-    profile: /default.png

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,3 @@ jwt:
 
 kakao:
   rest-api-key: ${KAKAO_RESTAPIKEY}
-
-image:
-  default:
-    profile: /default.png

--- a/src/test/java/com/zerototen/savegame/service/AuthServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/AuthServiceTest.java
@@ -4,9 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -20,6 +21,7 @@ import com.zerototen.savegame.repository.MemberRepository;
 import com.zerototen.savegame.security.TokenProvider;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -229,16 +231,18 @@ class AuthServiceTest {
         @DisplayName("성공")
         void success() {
             //given
+            HttpServletRequest request = mock(HttpServletRequest.class);
             Member member = getMember();
+            ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
 
-            given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(member));
+            willReturn(validateCheckResponse)
+                .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
             given(tokenProvider.deleteRefreshToken(any(Member.class)))
-                .willReturn(Boolean.TRUE);
+                .willReturn(Boolean.FALSE);
 
             //when
-            ResponseDto<?> responseDto = authService.withdrawal(1L);
+            ResponseDto<?> responseDto = authService.withdrawal(request);
 
             //then
             assertTrue(responseDto.isSuccess());
@@ -250,35 +254,45 @@ class AuthServiceTest {
         class Fail {
 
             @Test
-            @DisplayName("존재하지 않는 사용자")
-            void notFoundMember() {
-                //given
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.empty());
-
-                //when
-                ResponseDto<?> responseDto = authService.withdrawal(1L);
-
-                //then
-                assertEquals(ErrorCode.NOT_FOUND_MEMBER.getDetail(), responseDto.getData());
-            }
-
-            @Test
             @DisplayName("이미 탈퇴한 사용자")
             void alreadyWithdrawnMember() {
                 //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
                 Member member = getMember();
                 member.setDeletedAt(LocalDateTime.now());
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
 
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.of(member));
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                 //when
-                ResponseDto<?> responseDto = authService.withdrawal(1L);
+                ResponseDto<?> responseDto = authService.withdrawal(request);
 
                 //then
                 assertFalse(responseDto.isSuccess());
                 assertEquals("이미 탈퇴한 사용자입니다.", responseDto.getData());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 Refresh 토큰")
+            void notExistRefreshToken() {
+                //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
+                Member member = getMember();
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
+
+                given(tokenProvider.deleteRefreshToken(any(Member.class)))
+                    .willReturn(Boolean.TRUE);
+
+                //when
+                ResponseDto<?> responseDto = authService.withdrawal(request);
+
+                //then
+                assertFalse(responseDto.isSuccess());
+                assertEquals("존재하지 않는 Token 입니다.", responseDto.getData());
             }
         }
     }

--- a/src/test/java/com/zerototen/savegame/service/AuthServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/AuthServiceTest.java
@@ -239,7 +239,7 @@ class AuthServiceTest {
                 .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
             given(tokenProvider.deleteRefreshToken(any(Member.class)))
-                .willReturn(Boolean.FALSE);
+                .willReturn(Boolean.TRUE);
 
             //when
             ResponseDto<?> responseDto = authService.withdrawal(request);
@@ -285,7 +285,7 @@ class AuthServiceTest {
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                 given(tokenProvider.deleteRefreshToken(any(Member.class)))
-                    .willReturn(Boolean.TRUE);
+                    .willReturn(Boolean.FALSE);
 
                 //when
                 ResponseDto<?> responseDto = authService.withdrawal(request);

--- a/src/test/java/com/zerototen/savegame/service/MemberServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/MemberServiceTest.java
@@ -79,8 +79,7 @@ class MemberServiceTest {
                 HttpServletRequest request = mock(HttpServletRequest.class);
                 Member member = getMember();
                 ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
-                UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password11!!", "password11@@",
-                    "password11@@");
+                UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password11!!", "password11@@");
 
                 willReturn(validateCheckResponse)
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
@@ -94,51 +93,24 @@ class MemberServiceTest {
                 assertTrue(PasswordUtil.checkPassword(passwordRequest.getNewPassword(), member.getPassword()));
             }
 
-            @Nested
-            @DisplayName("실패")
-            class Fail {
+            @Test
+            @DisplayName("이전 비밀번호 불일치")
+            void fail_notMatchOldPassword() {
+                //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
+                Member member = getMember();
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password22!!", "password11@@");
 
-                @Test
-                @DisplayName("비밀번호 확인 불일치")
-                void notMatchNewPasswordCheck() {
-                    //given
-                    HttpServletRequest request = mock(HttpServletRequest.class);
-                    Member member = getMember();
-                    ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
-                    UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password11!!", "password11@@",
-                        "password11##");
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                    willReturn(validateCheckResponse)
-                        .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
+                //when
+                ResponseDto<?> responseDto = memberService.updatePassword(request, passwordRequest);
 
-                    //when
-                    ResponseDto<?> responseDto = memberService.updatePassword(request, passwordRequest);
-
-                    //then
-                    assertFalse(responseDto.isSuccess());
-                    assertEquals("비밀번호가 일치하지 않습니다.", responseDto.getData());
-                }
-
-                @Test
-                @DisplayName("이전 비밀번호 불일치")
-                void notMatchOldPassword() {
-                    //given
-                    HttpServletRequest request = mock(HttpServletRequest.class);
-                    Member member = getMember();
-                    ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
-                    UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password22!!", "password11@@",
-                        "password11@@");
-
-                    willReturn(validateCheckResponse)
-                        .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
-
-                    //when
-                    ResponseDto<?> responseDto = memberService.updatePassword(request, passwordRequest);
-
-                    //then
-                    assertFalse(responseDto.isSuccess());
-                    assertEquals("이전 비밀번호가 일치하지 않습니다.", responseDto.getData());
-                }
+                //then
+                assertFalse(responseDto.isSuccess());
+                assertEquals("이전 비밀번호가 일치하지 않습니다.", responseDto.getData());
             }
         }
 
@@ -238,11 +210,10 @@ class MemberServiceTest {
             .build();
     }
 
-    private static UpdatePasswordRequest getUpdatePasswordRequest(String oldPw, String newPw, String newPwChk) {
+    private static UpdatePasswordRequest getUpdatePasswordRequest(String oldPw, String newPw) {
         return UpdatePasswordRequest.builder()
             .oldPassword(oldPw)
             .newPassword(newPw)
-            .newPasswordCheck(newPwChk)
             .build();
     }
 

--- a/src/test/java/com/zerototen/savegame/service/MemberServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/MemberServiceTest.java
@@ -3,9 +3,11 @@ package com.zerototen.savegame.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
 
 import com.zerototen.savegame.domain.dto.request.UpdateNicknameRequest;
 import com.zerototen.savegame.domain.dto.request.UpdatePasswordRequest;
@@ -14,10 +16,11 @@ import com.zerototen.savegame.domain.dto.response.MemberResponse;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
 import com.zerototen.savegame.domain.entity.Member;
 import com.zerototen.savegame.domain.type.Authority;
-import com.zerototen.savegame.exception.ErrorCode;
 import com.zerototen.savegame.repository.MemberRepository;
+import com.zerototen.savegame.security.TokenProvider;
 import com.zerototen.savegame.util.PasswordUtil;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,50 +38,34 @@ class MemberServiceTest {
     @Mock
     MemberRepository memberRepository;
 
+    @Mock
+    TokenProvider tokenProvider;
+
     @Nested
     @DisplayName("마이페이지")
     class testMypage {
 
-        @Nested
-        @DisplayName("조회")
-        class GetDetail {
+        @Test
+        @DisplayName("조회 성공")
+        void getDetailSuccess() {
+            //given
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            Member member = getMember();
+            ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
 
-            @Test
-            @DisplayName("성공")
-            void success() {
-                //given
-                Member member = getMember();
+            willReturn(validateCheckResponse)
+                .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.of(member));
+            //when
+            ResponseDto<?> responseDto = memberService.getDetail(request);
+            MemberResponse response = (MemberResponse) responseDto.getData();
 
-                //when
-                ResponseDto<?> responseDto = memberService.getDetail(1L);
-                MemberResponse response = (MemberResponse) responseDto.getData();
-
-                //then
-                assertTrue(responseDto.isSuccess());
-                assertEquals("*".repeat(8), response.getPassword());
-                assertEquals(member.getEmail(), response.getEmail());
-                assertEquals(member.getNickname(), response.getNickname());
-                assertEquals(member.getProfileImageUrl(), response.getProfileImageUrl());
-            }
-
-            @Test
-            @DisplayName("실패 - 존재하지 않는 사용자")
-            void fail_NotFoundMember() {
-                //given
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.empty());
-
-                //when
-                ResponseDto<?> responseDto = memberService.getDetail(1L);
-
-                //then
-                assertFalse(responseDto.isSuccess());
-                assertEquals(ErrorCode.NOT_FOUND_MEMBER.getDetail(), responseDto.getData());
-            }
-
+            //then
+            assertTrue(responseDto.isSuccess());
+            assertEquals("*".repeat(8), response.getPassword());
+            assertEquals(member.getEmail(), response.getEmail());
+            assertEquals(member.getNickname(), response.getNickname());
+            assertEquals(member.getProfileImageUrl(), response.getProfileImageUrl());
         }
 
         @Nested
@@ -89,20 +76,22 @@ class MemberServiceTest {
             @DisplayName("성공")
             void success() {
                 //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
                 Member member = getMember();
-                UpdatePasswordRequest request = getUpdatePasswordRequest("password11!!", "password11@@",
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password11!!", "password11@@",
                     "password11@@");
 
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.of(member));
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                 //when
-                ResponseDto<?> responseDto = memberService.updatePassword(1L, request);
+                ResponseDto<?> responseDto = memberService.updatePassword(request, passwordRequest);
 
                 //then
                 assertTrue(responseDto.isSuccess());
                 assertEquals("Update Password Success", responseDto.getData());
-                assertTrue(PasswordUtil.checkPassword(request.getNewPassword(), member.getPassword()));
+                assertTrue(PasswordUtil.checkPassword(passwordRequest.getNewPassword(), member.getPassword()));
             }
 
             @Nested
@@ -110,36 +99,20 @@ class MemberServiceTest {
             class Fail {
 
                 @Test
-                @DisplayName("존재하지 않는 사용자")
-                void notFoundMember() {
-                    //given
-                    UpdatePasswordRequest request = getUpdatePasswordRequest("password11!!", "password11@@",
-                        "password11@@");
-
-                    given(memberRepository.findById(anyLong()))
-                        .willReturn(Optional.empty());
-
-                    //when
-                    ResponseDto<?> responseDto = memberService.updatePassword(1L, request);
-
-                    //then
-                    assertFalse(responseDto.isSuccess());
-                    assertEquals(ErrorCode.NOT_FOUND_MEMBER.getDetail(), responseDto.getData());
-                }
-
-                @Test
                 @DisplayName("비밀번호 확인 불일치")
                 void notMatchNewPasswordCheck() {
                     //given
+                    HttpServletRequest request = mock(HttpServletRequest.class);
                     Member member = getMember();
-                    UpdatePasswordRequest request = getUpdatePasswordRequest("password11!!", "password11@@",
+                    ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                    UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password11!!", "password11@@",
                         "password11##");
 
-                    given(memberRepository.findById(anyLong()))
-                        .willReturn(Optional.of(member));
+                    willReturn(validateCheckResponse)
+                        .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                     //when
-                    ResponseDto<?> responseDto = memberService.updatePassword(1L, request);
+                    ResponseDto<?> responseDto = memberService.updatePassword(request, passwordRequest);
 
                     //then
                     assertFalse(responseDto.isSuccess());
@@ -150,15 +123,17 @@ class MemberServiceTest {
                 @DisplayName("이전 비밀번호 불일치")
                 void notMatchOldPassword() {
                     //given
+                    HttpServletRequest request = mock(HttpServletRequest.class);
                     Member member = getMember();
-                    UpdatePasswordRequest request = getUpdatePasswordRequest("password22!!", "password11@@",
+                    ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                    UpdatePasswordRequest passwordRequest = getUpdatePasswordRequest("password22!!", "password11@@",
                         "password11@@");
 
-                    given(memberRepository.findById(anyLong()))
-                        .willReturn(Optional.of(member));
+                    willReturn(validateCheckResponse)
+                        .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                     //when
-                    ResponseDto<?> responseDto = memberService.updatePassword(1L, request);
+                    ResponseDto<?> responseDto = memberService.updatePassword(request, passwordRequest);
 
                     //then
                     assertFalse(responseDto.isSuccess());
@@ -175,72 +150,53 @@ class MemberServiceTest {
             @DisplayName("성공")
             void success() {
                 //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
                 Member member = getMember();
-                UpdateNicknameRequest request = getUpdateNicknameRequest("newNickname");
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                UpdateNicknameRequest nicknameRequest = getUpdateNicknameRequest("newNickname");
 
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.of(member));
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                 given(memberRepository.findByNickname(anyString()))
                     .willReturn(Optional.empty());
 
                 //when
-                ResponseDto<?> responseDto = memberService.updateNickname(1L, request);
+                ResponseDto<?> responseDto = memberService.updateNickname(request, nicknameRequest);
 
                 //then
                 assertTrue(responseDto.isSuccess());
                 assertEquals("Update Nickname Success", responseDto.getData());
-                assertEquals(request.getNickname(), member.getNickname());
+                assertEquals(nicknameRequest.getNickname(), member.getNickname());
             }
 
-            @Nested
-            @DisplayName("실패")
-            class Fail {
+            @Test
+            @DisplayName("실패 - 중복된 닉네임")
+            void fail_AlreadyExistNickname() {
+                //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
+                Member member = getMember();
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                UpdateNicknameRequest nicknameRequest = getUpdateNicknameRequest("newNickname");
 
-                @Test
-                @DisplayName("실패 - 존재하지 않는 사용자")
-                void notFoundMember() {
-                    //given
-                    UpdateNicknameRequest request = getUpdateNicknameRequest("newNickname");
+                Member sameNicknameMember = getMember();
+                sameNicknameMember.setId(2L);
+                sameNicknameMember.setEmail("same@gmail.com");
+                sameNicknameMember.setNickname(nicknameRequest.getNickname());
 
-                    given(memberRepository.findById(anyLong()))
-                        .willReturn(Optional.empty());
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                    //when
-                    ResponseDto<?> responseDto = memberService.updateNickname(1L, request);
+                given(memberRepository.findByNickname(anyString()))
+                    .willReturn(Optional.of(sameNicknameMember));
 
-                    //then
-                    assertFalse(responseDto.isSuccess());
-                    assertEquals(ErrorCode.NOT_FOUND_MEMBER.getDetail(), responseDto.getData());
-                }
+                //when
+                ResponseDto<?> responseDto = memberService.updateNickname(request, nicknameRequest);
 
-                @Test
-                @DisplayName("실패 - 중복된 닉네임")
-                void alreadyExistNickname() {
-                    //given
-                    Member member = getMember();
-                    UpdateNicknameRequest request = getUpdateNicknameRequest("newNickname");
-
-                    Member sameNicknameMember = getMember();
-                    sameNicknameMember.setId(2L);
-                    sameNicknameMember.setEmail("same@gmail.com");
-                    sameNicknameMember.setNickname(request.getNickname());
-
-                    given(memberRepository.findById(anyLong()))
-                        .willReturn(Optional.of(member));
-
-                    given(memberRepository.findByNickname(anyString()))
-                        .willReturn(Optional.of(sameNicknameMember));
-
-                    //when
-                    ResponseDto<?> responseDto = memberService.updateNickname(1L, request);
-
-                    //then
-                    assertFalse(responseDto.isSuccess());
-                    assertEquals("중복된 닉네임 입니다.", responseDto.getData());
-                }
+                //then
+                assertFalse(responseDto.isSuccess());
+                assertEquals("중복된 닉네임 입니다.", responseDto.getData());
             }
-
         }
 
         @Nested
@@ -251,38 +207,22 @@ class MemberServiceTest {
             @DisplayName("성공")
             void success() {
                 //given
+                HttpServletRequest request = mock(HttpServletRequest.class);
                 Member member = getMember();
-                UpdateProfileImageUrlRequest request = getUpdateProfileImageUrlRequest(
+                ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+                UpdateProfileImageUrlRequest imageUrlRequest = getUpdateProfileImageUrlRequest(
                     "http://image.com/profile/1.png");
 
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.of(member));
+                willReturn(validateCheckResponse)
+                    .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
                 //when
-                ResponseDto<?> responseDto = memberService.updateProfileImageUrl(1L, request);
+                ResponseDto<?> responseDto = memberService.updateProfileImageUrl(request, imageUrlRequest);
 
                 //then
                 assertTrue(responseDto.isSuccess());
                 assertEquals("Update Profile Image Success", responseDto.getData());
-                assertEquals(request.getProfileImageUrl(), member.getProfileImageUrl());
-            }
-
-            @Test
-            @DisplayName("실패 - 존재하지 않는 사용자")
-            void fail_NotFoundMember() {
-                //given
-                UpdateProfileImageUrlRequest request = getUpdateProfileImageUrlRequest(
-                    "http://image.com/profile/1.png");
-
-                given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.empty());
-
-                //when
-                ResponseDto<?> responseDto = memberService.updateProfileImageUrl(1L, request);
-
-                //then
-                assertFalse(responseDto.isSuccess());
-                assertEquals(ErrorCode.NOT_FOUND_MEMBER.getDetail(), responseDto.getData());
+                assertEquals(imageUrlRequest.getProfileImageUrl(), member.getProfileImageUrl());
             }
         }
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- Controller에서 @RequestHeader로 헤더를 받는 부분을 전부 HttpServletRequest로 받는 걸로 수정
- Controller 수정에 의한 Service 수정
- Service 수정으로 토큰 검증 및 토큰에서 Member를 구하는 코드 구현

**TO-BE**
- 챌린지 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

API 명세
- 다른 테스트의 경우 이전과 결과가 동일

#### 토큰 검증
- HttpServletRequest를 인자로 받는 모든 메소드에서 테스트
- 성공의 경우 결과는 이전과 동일

| 항목 | 요청 | 응답 | 비고 |
|----|----|----|----|
| 실패 - 요청의 Request에 Refresh Token이 없는 경우 | Header: Access Token  | {<br/>  "success": false,<br/>    "data": "로그인이 필요합니다."<br/>} |    |
| 실패 - 요청의 Request에 Access Token이 없는 경우 | Header: Refresh Token  | {<br/>  "success": false,<br/>    "data": "로그인이 필요합니다."<br/>} |    |
| 실패 - Blacklist에 등록된 Access Token | Header: Access Token(블랙리스트에 존재), <br/>Refresh Token| {<br/>  "success": false,<br/>    "data": "Token이 유효하지 않습니다."<br/>} | |
| 로그인 실패 - 중복 로그인 | Header: Access Token, <br/>Refresh Token| {<br/>  "success": false,<br/>   "data": "이미 로그인되어 있습니다."<br/>} | DB에 이미 Refresh Token이 존재한 경우 |
