### PR TITLE
[feat-challenge-join] 챌린지 참가 기능 구현

### DIFF
--- a/src/main/java/com/zerototen/savegame/controller/ChallengeController.java
+++ b/src/main/java/com/zerototen/savegame/controller/ChallengeController.java
@@ -7,6 +7,7 @@ import com.zerototen.savegame.service.ChallengeService;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +25,13 @@ public class ChallengeController {
     public ResponseDto<?> createChallenge(HttpServletRequest request,
         @RequestBody @Valid CreateChallengeRequest createRequest) {
         return challengeService.create(request, CreateChallengeServiceDto.from(createRequest));
+    }
+
+    // 챌린지 참가
+    @PostMapping("/{challengeId}/join")
+    public ResponseDto<?> joinChallenge(HttpServletRequest request,
+        @PathVariable Long challengeId) {
+        return challengeService.join(request, challengeId);
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/controller/ChallengeController.java
+++ b/src/main/java/com/zerototen/savegame/controller/ChallengeController.java
@@ -7,10 +7,10 @@ import com.zerototen.savegame.service.ChallengeService;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,9 +28,9 @@ public class ChallengeController {
     }
 
     // 챌린지 참가
-    @PostMapping("/{challengeId}/join")
+    @PostMapping("/join")
     public ResponseDto<?> joinChallenge(HttpServletRequest request,
-        @PathVariable Long challengeId) {
+        @RequestParam Long challengeId) {
         return challengeService.join(request, challengeId);
     }
 

--- a/src/main/java/com/zerototen/savegame/controller/RecordController.java
+++ b/src/main/java/com/zerototen/savegame/controller/RecordController.java
@@ -58,7 +58,7 @@ public class RecordController {
     public ResponseDto<?> updateRecord(
         HttpServletRequest request, @PathVariable Long recordId,
         @RequestBody @Valid UpdateRecordRequest updateRecordRequest) {
-        return recordService.update(request, UpdateRecordServiceDto.from(recordId, updateRecordRequest));
+        return recordService.update(request, UpdateRecordServiceDto.of(recordId, updateRecordRequest));
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/zerototen/savegame/domain/dto/UpdateRecordServiceDto.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/UpdateRecordServiceDto.java
@@ -25,7 +25,7 @@ public class UpdateRecordServiceDto {
     private LocalDate useDate;
     private PayType payType;
 
-    public static UpdateRecordServiceDto from(Long recordId, UpdateRecordRequest request) {
+    public static UpdateRecordServiceDto of(Long recordId, UpdateRecordRequest request) {
         return UpdateRecordServiceDto.builder()
             .id(recordId)
             .amount(request.getAmount())

--- a/src/main/java/com/zerototen/savegame/domain/entity/Challenge.java
+++ b/src/main/java/com/zerototen/savegame/domain/entity/Challenge.java
@@ -34,11 +34,19 @@ public class Challenge extends BaseEntity {
     @Column(name = "challenge_id")
     private Long id;
 
-    private Long createMemberId;
+    @Column(nullable = false)
+    private Long masterMemberId;
 
+    @Column(nullable = false)
     private String title;
+
+    @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
     private LocalDate startDate;
+
+    @Column(nullable = false)
     private LocalDate endDate;
     private int goalAmount;
 
@@ -48,9 +56,9 @@ public class Challenge extends BaseEntity {
     private int maxPeople;
     private LocalDateTime deletedAt;
 
-    public static Challenge from(CreateChallengeServiceDto serviceDto, Long memberId) {
+    public static Challenge of(CreateChallengeServiceDto serviceDto, Long memberId) {
         return Challenge.builder()
-            .createMemberId(memberId)
+            .masterMemberId(memberId)
             .title(serviceDto.getTitle())
             .content(serviceDto.getContent())
             .startDate(serviceDto.getStartDate())

--- a/src/main/java/com/zerototen/savegame/domain/entity/Challenge.java
+++ b/src/main/java/com/zerototen/savegame/domain/entity/Challenge.java
@@ -34,6 +34,8 @@ public class Challenge extends BaseEntity {
     @Column(name = "challenge_id")
     private Long id;
 
+    private Long createMemberId;
+
     private String title;
     private String content;
     private LocalDate startDate;
@@ -46,8 +48,9 @@ public class Challenge extends BaseEntity {
     private int maxPeople;
     private LocalDateTime deletedAt;
 
-    public static Challenge from(CreateChallengeServiceDto serviceDto) {
+    public static Challenge from(CreateChallengeServiceDto serviceDto, Long memberId) {
         return Challenge.builder()
+            .createMemberId(memberId)
             .title(serviceDto.getTitle())
             .content(serviceDto.getContent())
             .startDate(serviceDto.getStartDate())

--- a/src/main/java/com/zerototen/savegame/domain/entity/Record.java
+++ b/src/main/java/com/zerototen/savegame/domain/entity/Record.java
@@ -60,7 +60,7 @@ public class Record {
         this.payType = serviceDto.getPayType();
     }
 
-    public static Record from(Long memberId, CreateRecordServiceDto serviceDto) {
+    public static Record of(Long memberId, CreateRecordServiceDto serviceDto) {
         return Record.builder()
             .memberId(memberId)
             .amount(serviceDto.getAmount())

--- a/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepository.java
@@ -1,10 +1,16 @@
 package com.zerototen.savegame.repository;
 
+import com.zerototen.savegame.domain.entity.Challenge;
 import com.zerototen.savegame.domain.entity.ChallengeMember;
+import com.zerototen.savegame.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
+
+    boolean existsByMemberAndChallenge(Member member, Challenge challenge);
+
+    int countByChallenge(Challenge challenge);
 
 }

--- a/src/main/java/com/zerototen/savegame/service/ChallengeService.java
+++ b/src/main/java/com/zerototen/savegame/service/ChallengeService.java
@@ -8,6 +8,7 @@ import com.zerototen.savegame.domain.entity.Member;
 import com.zerototen.savegame.repository.ChallengeMemberRepository;
 import com.zerototen.savegame.repository.ChallengeRepository;
 import com.zerototen.savegame.security.TokenProvider;
+import java.time.LocalDate;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +33,9 @@ public class ChallengeService {
 
         Member member = (Member) responseDto.getData();
 
-        Challenge challenge = challengeRepository.save(Challenge.from(serviceDto));
-        log.info("Create challenge -> challengeId: {}", challenge.getId());
+        Challenge challenge = challengeRepository.save(Challenge.from(serviceDto, member.getId()));
+        log.info("Create challenge -> challengeId: {}, createMemberId: {}", challenge.getId(),
+            challenge.getCreateMemberId());
 
         ChallengeMember challengeMember = ChallengeMember.builder()
             .challenge(challenge)
@@ -45,6 +47,43 @@ public class ChallengeService {
         log.info("Add challenge member -> challengeId: {}, memberId: {}", challenge.getId(), member.getId());
 
         return ResponseDto.success(challenge);
+    }
+
+    @Transactional
+    public ResponseDto<?> join(HttpServletRequest request, Long challengeId) {
+        ResponseDto<?> responseDto = tokenProvider.validateCheck(request);
+        if (!responseDto.isSuccess()) {
+            return responseDto;
+        }
+
+        Member member = (Member) responseDto.getData();
+
+        Challenge challenge = challengeRepository.findById(challengeId).orElse(null);
+        if (challenge == null) {
+            return ResponseDto.fail("챌린지가 존재하지 않습니다.");
+        }
+
+        if (challengeMemberRepository.existsByMemberAndChallenge(member, challenge)) {
+            return ResponseDto.fail("이미 참가한 챌린지입니다.");
+        }
+
+        if (challenge.getEndDate().isBefore(LocalDate.now())) {
+            return ResponseDto.fail("이미 완료된 챌린지입니다.");
+        }
+
+        if (challengeMemberRepository.countByChallenge(challenge) >= challenge.getMaxPeople()) {
+            return ResponseDto.fail("인원이 다 찼습니다.");
+        }
+
+        ChallengeMember challengeMember = ChallengeMember.builder()
+            .member(member)
+            .challenge(challenge)
+            .ongoingYn(true)
+            .build();
+
+        challengeMemberRepository.save(challengeMember);
+        log.info("Add challenge member -> challengeId: {}, memberId: {}", challengeId, member.getId());
+        return ResponseDto.success("Join Challenge Success");
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/service/ChallengeService.java
+++ b/src/main/java/com/zerototen/savegame/service/ChallengeService.java
@@ -68,7 +68,7 @@ public class ChallengeService {
         }
 
         if (challenge.getEndDate().isBefore(LocalDate.now())) {
-            return ResponseDto.fail("이미 완료된 챌린지입니다.");
+            return ResponseDto.fail("이미 종료된 챌린지입니다.");
         }
 
         if (challengeMemberRepository.countByChallenge(challenge) >= challenge.getMaxPeople()) {

--- a/src/main/java/com/zerototen/savegame/service/ChallengeService.java
+++ b/src/main/java/com/zerototen/savegame/service/ChallengeService.java
@@ -33,9 +33,9 @@ public class ChallengeService {
 
         Member member = (Member) responseDto.getData();
 
-        Challenge challenge = challengeRepository.save(Challenge.from(serviceDto, member.getId()));
+        Challenge challenge = challengeRepository.save(Challenge.of(serviceDto, member.getId()));
         log.info("Create challenge -> challengeId: {}, createMemberId: {}", challenge.getId(),
-            challenge.getCreateMemberId());
+            challenge.getMasterMemberId());
 
         ChallengeMember challengeMember = ChallengeMember.builder()
             .challenge(challenge)
@@ -58,7 +58,8 @@ public class ChallengeService {
 
         Member member = (Member) responseDto.getData();
 
-        Challenge challenge = challengeRepository.findById(challengeId).orElse(null);
+        Challenge challenge = challengeRepository.findById(challengeId)
+            .orElse(null);
         if (challenge == null) {
             return ResponseDto.fail("챌린지가 존재하지 않습니다.");
         }
@@ -67,8 +68,8 @@ public class ChallengeService {
             return ResponseDto.fail("이미 참가한 챌린지입니다.");
         }
 
-        if (challenge.getEndDate().isBefore(LocalDate.now())) {
-            return ResponseDto.fail("이미 종료된 챌린지입니다.");
+        if (challenge.getEndDate().isBefore(LocalDate.now())) { // 종료일이 오늘 이전이면
+            return ResponseDto.fail("이미 종료된 챌린지입니다."); // TODO: 중도참가 허용?
         }
 
         if (challengeMemberRepository.countByChallenge(challenge) >= challenge.getMaxPeople()) {

--- a/src/main/java/com/zerototen/savegame/service/RecordService.java
+++ b/src/main/java/com/zerototen/savegame/service/RecordService.java
@@ -40,7 +40,7 @@ public class RecordService {
         Member member = (Member) responseDto.getData();
 
         log.debug("Create record -> memberId: {}", member.getId());
-        return ResponseDto.success(recordRepository.save(Record.from(member.getId(), serviceDto)));
+        return ResponseDto.success(recordRepository.save(Record.of(member.getId(), serviceDto)));
     }
 
     // 지출 내역 조회 (가계부 메인)

--- a/src/test/java/com/zerototen/savegame/service/ChallengeServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/ChallengeServiceTest.java
@@ -1,12 +1,15 @@
 package com.zerototen.savegame.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 import com.zerototen.savegame.domain.dto.CreateChallengeServiceDto;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
@@ -18,8 +21,10 @@ import com.zerototen.savegame.repository.ChallengeMemberRepository;
 import com.zerototen.savegame.repository.ChallengeRepository;
 import com.zerototen.savegame.security.TokenProvider;
 import java.time.LocalDate;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -50,7 +55,7 @@ class ChallengeServiceTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         Member member = getMember();
         ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
-        Challenge challenge = getChallenge(Category.FOOD);
+        Challenge challenge = getChallenge(Category.FOOD, member.getId());
 
         willReturn(validateCheckResponse)
             .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
@@ -68,6 +73,7 @@ class ChallengeServiceTest {
         then(challengeRepository).should().save(challengeArgumentCaptor.capture());
         then(challengeMemberRepository).should().save(challengeMemberArgumentCaptor.capture());
         assertTrue(responseDto.isSuccess());
+        assertEquals(member.getId(), challengeArgumentCaptor.getValue().getCreateMemberId());
         assertEquals(serviceDto.getTitle(), challengeArgumentCaptor.getValue().getTitle());
         assertEquals(serviceDto.getContent(), challengeArgumentCaptor.getValue().getContent());
         assertEquals(serviceDto.getStartDate(), challengeArgumentCaptor.getValue().getStartDate());
@@ -75,6 +81,76 @@ class ChallengeServiceTest {
         assertEquals(serviceDto.getGoalAmount(), challengeArgumentCaptor.getValue().getGoalAmount());
         assertEquals(serviceDto.getCategory(), challengeArgumentCaptor.getValue().getCategory());
         assertEquals(serviceDto.getMaxPeople(), challengeArgumentCaptor.getValue().getMaxPeople());
+    }
+
+    @Nested
+    @DisplayName("챌린지 참가")
+    class testJoinChallenge {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            Member member = getMember();
+            ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+            Challenge challenge = getChallenge(Category.FOOD, member.getId());
+
+            willReturn(validateCheckResponse)
+                .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
+
+            given(challengeRepository.findById(anyLong()))
+                .willReturn(Optional.of(challenge));
+
+            given(challengeMemberRepository.existsByMemberAndChallenge(any(Member.class), any(Challenge.class)))
+                .willReturn(Boolean.FALSE);
+
+            given(challengeMemberRepository.countByChallenge(any(Challenge.class)))
+                .willReturn(challenge.getMaxPeople() - 1);
+
+            ArgumentCaptor<ChallengeMember> argumentCaptor = ArgumentCaptor.forClass(ChallengeMember.class);
+
+            //when
+            ResponseDto<?> responseDto = challengeService.join(request, 1L);
+
+            //then
+            then(challengeMemberRepository).should().save(argumentCaptor.capture());
+            assertEquals(member, argumentCaptor.getValue().getMember());
+            assertEquals(challenge, argumentCaptor.getValue().getChallenge());
+            assertTrue(argumentCaptor.getValue().isOngoingYn());
+            assertTrue(responseDto.isSuccess());
+            assertEquals("Join Challenge Success", responseDto.getData());
+
+        }
+
+        @Test
+        @DisplayName("실패 - 인원이 가득찬 챌린지")
+        void fail_ChallengeIsFull() {
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            Member member = getMember();
+            ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
+            Challenge challenge = getChallenge(Category.FOOD, member.getId());
+
+            willReturn(validateCheckResponse)
+                .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
+
+            given(challengeRepository.findById(anyLong()))
+                .willReturn(Optional.of(challenge));
+
+            given(challengeMemberRepository.existsByMemberAndChallenge(any(Member.class), any(Challenge.class)))
+                .willReturn(Boolean.FALSE);
+
+            given(challengeMemberRepository.countByChallenge(any(Challenge.class)))
+                .willReturn(challenge.getMaxPeople());
+
+            //when
+            ResponseDto<?> responseDto = challengeService.join(request, 1L);
+
+            //then
+            then(challengeMemberRepository).should(never()).save(any());
+            assertFalse(responseDto.isSuccess());
+            assertEquals("인원이 다 찼습니다.", responseDto.getData());
+        }
     }
 
     private Member getMember() {
@@ -87,9 +163,10 @@ class ChallengeServiceTest {
             .build();
     }
 
-    private static Challenge getChallenge(Category category) {
+    private static Challenge getChallenge(Category category, Long createMemberId) {
         return Challenge.builder()
             .id(1L)
+            .createMemberId(createMemberId)
             .title("title")
             .content("content")
             .startDate(LocalDate.of(2023, 7, 1))

--- a/src/test/java/com/zerototen/savegame/service/ChallengeServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/ChallengeServiceTest.java
@@ -73,7 +73,7 @@ class ChallengeServiceTest {
         then(challengeRepository).should().save(challengeArgumentCaptor.capture());
         then(challengeMemberRepository).should().save(challengeMemberArgumentCaptor.capture());
         assertTrue(responseDto.isSuccess());
-        assertEquals(member.getId(), challengeArgumentCaptor.getValue().getCreateMemberId());
+        assertEquals(member.getId(), challengeArgumentCaptor.getValue().getMasterMemberId());
         assertEquals(serviceDto.getTitle(), challengeArgumentCaptor.getValue().getTitle());
         assertEquals(serviceDto.getContent(), challengeArgumentCaptor.getValue().getContent());
         assertEquals(serviceDto.getStartDate(), challengeArgumentCaptor.getValue().getStartDate());
@@ -158,7 +158,7 @@ class ChallengeServiceTest {
 
             @Test
             @DisplayName("이미 종료된 챌린지")
-            void fail_ChallengeIsAlreadyEnd() {
+            void alreadyEndedChallenge() {
                 HttpServletRequest request = mock(HttpServletRequest.class);
                 Member member = getMember();
                 ResponseDto<?> validateCheckResponse = ResponseDto.success(member);
@@ -185,7 +185,7 @@ class ChallengeServiceTest {
         }
     }
 
-    private Member getMember() {
+    private static Member getMember() {
         return Member.builder()
             .id(2L)
             .email("abc@gmail.com")
@@ -198,7 +198,7 @@ class ChallengeServiceTest {
     private static Challenge getChallenge(Category category, Long createMemberId) {
         return Challenge.builder()
             .id(1L)
-            .createMemberId(createMemberId)
+            .masterMemberId(createMemberId)
             .title("title")
             .content("content")
             .startDate(LocalDate.of(2023, 7, 1))


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 챌린지 참가 기능 구현
- 참기 인원이 다 차지 않고, 완료가 되지 않은 경우 참가 가능
- 회의 결과에 따라 생성한 Member의 id를 Challenge Entity에 추가

**TO-BE**
- 챌린지 나가기 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

API 명세

#### 챌린지 참가
- challengeId: 1인 chllalenge 존재
- 해당 챌린지에 참가 중이지 않은 member로 요청

| 항목 | 요청 | 응답 | 비고 |
|----|----|----|----|
| 성공  |요청url: /challenge/join?challengeId=1  |{<br/>    "success": true,<br/>    "data": "Join Challenge Success"<br/>} | DB에 등록 확인  |
| 실패 - 인원이 다 찬 챌린지 | 요청url: /challenge/join?challengeId=1 | {<br/>    "success": false,<br/>    "data": "인원이 다 찼습니다."<br/>} | 인원이 다 찬 상태  |
| 실패 - 이미 종료된 챌린지 | 요청url: /challenge/join?challengeId=1 | {<br/>    "success": false,<br/>    "data": "이미 완료된 챌린지입니다."<br/>} | 챌린지 종료일이 지난 상태 |