### PR TITLE
[feat-challenge-exit] 챌린지 나가기 기능 구현

### DIFF
--- a/src/main/java/com/zerototen/savegame/controller/ChallengeController.java
+++ b/src/main/java/com/zerototen/savegame/controller/ChallengeController.java
@@ -7,6 +7,7 @@ import com.zerototen.savegame.service.ChallengeService;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,13 @@ public class ChallengeController {
     public ResponseDto<?> joinChallenge(HttpServletRequest request,
         @RequestParam Long challengeId) {
         return challengeService.join(request, challengeId);
+    }
+
+    // 챌린지 나가기
+    @DeleteMapping("/exit")
+    public ResponseDto<?> exitChallenge(HttpServletRequest request,
+        @RequestParam Long challengeId) {
+        return challengeService.exit(request, challengeId);
     }
 
 }

--- a/src/main/java/com/zerototen/savegame/controller/PostController.java
+++ b/src/main/java/com/zerototen/savegame/controller/PostController.java
@@ -7,15 +7,22 @@ import com.zerototen.savegame.domain.dto.request.CreatePostRequest;
 import com.zerototen.savegame.domain.dto.request.UpdatePostRequest;
 import com.zerototen.savegame.domain.dto.response.ResponseDto;
 import com.zerototen.savegame.service.PostService;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @Slf4j
@@ -28,21 +35,22 @@ public class PostController {
 
     @GetMapping("/challenge/{challengeId}")
     public ResponseDto<?> challengePosts(HttpServletRequest request, @PathVariable Long challengeId,
-                                         @PageableDefault(10) Pageable pageable) {
+        @PageableDefault(10) Pageable pageable) {
         return postService.getPostList(challengeId, request, pageable);
     }
 
     @PostMapping
     public ResponseDto<?> post(HttpServletRequest request, @RequestParam List<String> imageList,
-                               @RequestParam Long challengeId, @RequestBody @Valid CreatePostRequest postRequest) {
+        @RequestParam Long challengeId, @RequestBody @Valid CreatePostRequest postRequest) {
         // 이미지 이름 중복 없이 시분초+보드id로 작명될 수 있도록 요청 필요
-        return postService.create(CreatePostServiceDto.from(postRequest), imageList, challengeId, request);
+        return postService.create(CreatePostServiceDto.from(postRequest), imageList, challengeId,
+            request);
     }
 
     //인스타그램 확인 시, 사진 수정/삭제 기능 없음, 필요하면 추가 필요
     @PutMapping("/{postId}")
     public ResponseDto<?> updatePost(HttpServletRequest request, @PathVariable Long postId,
-                                     @RequestBody @Valid UpdatePostRequest updatePostRequest) {
+        @RequestBody @Valid UpdatePostRequest updatePostRequest) {
         return postService.update(request, UpdatePostServiceDto.of(postId, updatePostRequest));
     }
 

--- a/src/main/java/com/zerototen/savegame/controller/RecordController.java
+++ b/src/main/java/com/zerototen/savegame/controller/RecordController.java
@@ -50,7 +50,8 @@ public class RecordController {
 
     @GetMapping("/analysis")
     public ResponseDto<?> getAnalysisInfo(
-        HttpServletRequest request, @RequestParam int year, @RequestParam @Valid @Min(1) @Max(12) int month) {
+        HttpServletRequest request, @RequestParam int year,
+        @RequestParam @Valid @Min(1) @Max(12) int month) {
         return recordService.getAnalysisInfo(request, year, month);
     }
 
@@ -58,7 +59,8 @@ public class RecordController {
     public ResponseDto<?> updateRecord(
         HttpServletRequest request, @PathVariable Long recordId,
         @RequestBody @Valid UpdateRecordRequest updateRecordRequest) {
-        return recordService.update(request, UpdateRecordServiceDto.of(recordId, updateRecordRequest));
+        return recordService.update(request,
+            UpdateRecordServiceDto.of(recordId, updateRecordRequest));
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepository.java
@@ -3,11 +3,14 @@ package com.zerototen.savegame.repository;
 import com.zerototen.savegame.domain.entity.Challenge;
 import com.zerototen.savegame.domain.entity.ChallengeMember;
 import com.zerototen.savegame.domain.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
+
+    Optional<ChallengeMember> findByMemberAndChallenge(Member member, Challenge challenge);
 
     boolean existsByMemberAndChallenge(Member member, Challenge challenge);
 

--- a/src/test/java/com/zerototen/savegame/service/RecordServiceTest.java
+++ b/src/test/java/com/zerototen/savegame/service/RecordServiceTest.java
@@ -102,7 +102,8 @@ class RecordServiceTest {
                 willReturn(validateCheckResponse)
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                given(recordRepository.findByMemberAndUseDateDescWithOptional(any(Member.class), any(LocalDate.class),
+                given(recordRepository.findByMemberAndUseDateDescWithOptional(any(Member.class),
+                    any(LocalDate.class),
                     any(LocalDate.class), isNull()))
                     .willReturn(records);
 
@@ -124,7 +125,8 @@ class RecordServiceTest {
                         recordResponses.get(size - i).getCategory());
                     assertEquals("가게" + i, recordResponses.get(size - i).getPaidFor());
                     assertEquals("메모" + i, recordResponses.get(size - i).getMemo());
-                    assertEquals(LocalDate.of(2023, 6, i), recordResponses.get(size - i).getUseDate());
+                    assertEquals(LocalDate.of(2023, 6, i),
+                        recordResponses.get(size - i).getUseDate());
                     assertEquals(PayType.values()[(i - 1) % PAYTYPE_LENGTH].getName(),
                         recordResponses.get(size - i).getPayType());
                 }
@@ -143,7 +145,8 @@ class RecordServiceTest {
                 willReturn(validateCheckResponse)
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                given(recordRepository.findByMemberAndUseDateDescWithOptional(any(Member.class), any(LocalDate.class),
+                given(recordRepository.findByMemberAndUseDateDescWithOptional(any(Member.class),
+                    any(LocalDate.class),
                     any(LocalDate.class), anyList()))
                     .willReturn(records);
 
@@ -164,7 +167,8 @@ class RecordServiceTest {
                         recordResponses.get(size - i).getCategory());
                     assertEquals("가게" + i, recordResponses.get(size - i).getPaidFor());
                     assertEquals("메모" + i, recordResponses.get(size - i).getMemo());
-                    assertEquals(LocalDate.of(2023, 6, i), recordResponses.get(size - i).getUseDate());
+                    assertEquals(LocalDate.of(2023, 6, i),
+                        recordResponses.get(size - i).getUseDate());
                     assertEquals(PayType.values()[(i - 1) % PAYTYPE_LENGTH].getName(),
                         recordResponses.get(size - i).getPayType());
                 }
@@ -209,7 +213,8 @@ class RecordServiceTest {
             willReturn(validateCheckResponse)
                 .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-            given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class), any(LocalDate.class),
+            given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class),
+                any(LocalDate.class),
                 any(LocalDate.class)))
                 .willReturn(serviceDtos);
 
@@ -219,8 +224,9 @@ class RecordServiceTest {
 
             //then
             assertTrue(responseDto.isSuccess());
-            then(recordRepository).should().findByMemberAndUseDateAndAmountSumDesc(any(Member.class), any(LocalDate.class),
-                any(LocalDate.class));
+            then(recordRepository).should()
+                .findByMemberAndUseDateAndAmountSumDesc(any(Member.class), any(LocalDate.class),
+                    any(LocalDate.class));
             int size = responses.size();
             for (int i = size; i >= 1; i--) {
                 assertEquals(Category.values()[(i - 1) % CATEGORY_LENGTH].getName(),
@@ -246,7 +252,8 @@ class RecordServiceTest {
                 willReturn(validateCheckResponse)
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class), any(LocalDate.class),
+                given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class),
+                    any(LocalDate.class),
                     any(LocalDate.class)))
                     .willReturn(serviceDtos);
 
@@ -271,7 +278,8 @@ class RecordServiceTest {
                 willReturn(validateCheckResponse)
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class), any(LocalDate.class),
+                given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class),
+                    any(LocalDate.class),
                     any(LocalDate.class)))
                     .willReturn(serviceDtos);
 
@@ -296,7 +304,8 @@ class RecordServiceTest {
                 willReturn(validateCheckResponse)
                     .given(tokenProvider).validateCheck(any(HttpServletRequest.class));
 
-                given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class), any(LocalDate.class),
+                given(recordRepository.findByMemberAndUseDateAndAmountSumDesc(any(Member.class),
+                    any(LocalDate.class),
                     any(LocalDate.class)))
                     .willReturn(serviceDtos);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 챌린지 생성 사용자가 아니고 챌린지 시작 전인 경우 나가기 가능

**TO-BE**
- 사용자 챌린지 조회 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

API 명세

#### 챌린지 나가기
- challengeId 1인 챌린지에 참가한 챌린지를 생성하지 않은 사용자

| 항목 | 요청 | 응답 | 비고 |
|----|----|----|----|
| 성공 | exit?challengeId=1   | {<br/> "success": true,<br/>    "data": "Exit Challenge Success"<br/>} | DB에 삭제 확인 |
| 실패 - 이미 시작된 챌린지 | exit?challengeId=1 | {<br/>    "success": false,<br/>    "data": "이미 시작된 챌린지입니다."<br/>}  | 챌린지가 이미 시작한 경우 | 
