### PR TITLE
[feat-member-getchallenge] 사용자 챌린지 조회 기능 구현

### DIFF
--- a/src/main/java/com/zerototen/savegame/controller/MemberController.java
+++ b/src/main/java/com/zerototen/savegame/controller/MemberController.java
@@ -51,7 +51,7 @@ public class MemberController {
     }
 
     // 멤버 챌린지 조회
-    @GetMapping("/challenge")
+    @GetMapping("/challenges")
     public ResponseDto<?> getMemberChallengeList(HttpServletRequest request) {
         return memberService.getMemberChallengeList(request);
     }

--- a/src/main/java/com/zerototen/savegame/controller/MemberController.java
+++ b/src/main/java/com/zerototen/savegame/controller/MemberController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/zerototen/savegame/controller/MemberController.java
+++ b/src/main/java/com/zerototen/savegame/controller/MemberController.java
@@ -50,4 +50,10 @@ public class MemberController {
         return memberService.updateProfileImageUrl(request, imageUrlRequest);
     }
 
+    // 멤버 챌린지 조회
+    @GetMapping("/challenge")
+    public ResponseDto<?> getMemberChallengeList(HttpServletRequest request) {
+        return memberService.getMemberChallengeList(request);
+    }
+
 }

--- a/src/main/java/com/zerototen/savegame/domain/dto/response/MemberChallengeResponse.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/response/MemberChallengeResponse.java
@@ -1,0 +1,30 @@
+package com.zerototen.savegame.domain.dto.response;
+
+import com.zerototen.savegame.domain.entity.Challenge;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberChallengeResponse {
+
+    private Long challengeId;
+
+    private String title;
+
+    private LocalDate endDate;
+
+    public static MemberChallengeResponse from(Challenge challenge) {
+        return MemberChallengeResponse.builder()
+            .challengeId(challenge.getId())
+            .title(challenge.getTitle())
+            .endDate(challenge.getEndDate())
+            .build();
+    }
+
+}

--- a/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepository.java
+++ b/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long> {
+public interface ChallengeMemberRepository extends JpaRepository<ChallengeMember, Long>,
+    ChallengeMemberRepositoryCustom {
 
     Optional<ChallengeMember> findByMemberAndChallenge(Member member, Challenge challenge);
 

--- a/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepositoryCustom.java
+++ b/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.zerototen.savegame.repository;
+
+import com.zerototen.savegame.domain.entity.Challenge;
+import com.zerototen.savegame.domain.entity.Member;
+import java.util.List;
+
+public interface ChallengeMemberRepositoryCustom {
+
+    List<Challenge> findChallengeListByMemberOrderByEndDate(Member member);
+
+}

--- a/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepositoryImpl.java
+++ b/src/main/java/com/zerototen/savegame/repository/ChallengeMemberRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.zerototen.savegame.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerototen.savegame.domain.entity.Challenge;
+import com.zerototen.savegame.domain.entity.Member;
+import com.zerototen.savegame.domain.entity.QChallengeMember;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChallengeMemberRepositoryImpl implements ChallengeMemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Challenge> findChallengeListByMemberOrderByEndDate(Member member) {
+
+        QChallengeMember challengeMember = QChallengeMember.challengeMember;
+
+        BooleanExpression condition = challengeMember.member.eq(member)
+            .and(challengeMember.challenge.endDate.after(
+                LocalDate.now().minusDays(1))); // 종료된 챌린지는 조회하지 않음
+
+        return new ArrayList<>(queryFactory
+            .select(challengeMember.challenge)
+            .from(challengeMember)
+            .where(condition)
+            .orderBy(challengeMember.challenge.endDate.asc())
+            .fetch());
+    }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 현재 로그인 중인 사용자가 진행 중인 챌린지 조회 기능 구현
- 이미 종료된 챌린지는 미조회
- 종료일의 오름차순으로 정렬

**TO-BE**
- 챌린지 검색 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

API 명세

#### 사용자 챌린지 조회

| 항목 | 요청 | 응답 | 비고 |
|----|----|----|----|
| 성공 | member/challenge | {<br/>    "success": true,<br/>    "data": [<br/>        {<br/>            "challengeId": 4,<br/>            "title": "제목",<br/>            "endDate": "2023-06-29"<br/>        },<br/>        {<br/>            "challengeId": 3,<br/>            "title": "제목",<br/>            "endDate": "2023-07-01"<br/>        },<br/>        {<br/>            "challengeId": 1,<br/>            "title": "제목",<br/>            "endDate": "2023-08-01"<br/>        }<br/>    ]<br/>}   |  - 요청 member는 challengeId 1~4에 참가중 <br/> - challengeId: 2는 이미 종료된 챌린지  |
