### PR TITLE
[fix-challenge-getstatus] 챌린지 단건 조회 응답 항목 추가

### DIFF
--- a/src/main/java/com/zerototen/savegame/domain/dto/response/ChallengeMemberResponse.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/response/ChallengeMemberResponse.java
@@ -14,6 +14,7 @@ public class ChallengeMemberResponse {
 
     private Long memberId;
     private String nickname;
+    private String profileImageUrl;
     private int status;
     private long totalAmount;
     private List<ChallengeRecordResponse> recordList;

--- a/src/main/java/com/zerototen/savegame/domain/dto/response/ChallengeMemberResultResponse.java
+++ b/src/main/java/com/zerototen/savegame/domain/dto/response/ChallengeMemberResultResponse.java
@@ -13,6 +13,7 @@ public class ChallengeMemberResultResponse {
 
     private Long memberId;
     private String nickname;
+    private String profileImageUrl;
     private int status;
     private long totalAmount;
 

--- a/src/main/java/com/zerototen/savegame/service/ChallengeService.java
+++ b/src/main/java/com/zerototen/savegame/service/ChallengeService.java
@@ -173,11 +173,12 @@ public class ChallengeService {
 
             for (ChallengeMember challengeMember : challengeMemberList) {
                 List<ChallengeRecordResponse> recordList = new ArrayList<>();
+                Member member = challengeMember.getMember();
                 long total = 0L;
                 if (!challenge.getStartDate().isAfter(LocalDate.now())) { // 챌린지 시작 후
                     // 챌린지 멤버의 지출 리스트
                     recordList = recordRepository.findTotalAndUseDateByMemberAndChallengeGroupByUseDate(
-                        challengeMember.getMember(), challenge);
+                        member, challenge);
 
                     total = recordList.stream().mapToLong(ChallengeRecordResponse::getAmount)
                         .sum();
@@ -192,8 +193,9 @@ public class ChallengeService {
                     }
                 }
                 challengeMemberResponseList.add(ChallengeMemberResponse.builder()
-                    .memberId(challengeMember.getMember().getId())
-                    .nickname(challengeMember.getMember().getNickname())
+                    .memberId(member.getId())
+                    .nickname(member.getNickname())
+                    .profileImageUrl(member.getProfileImageUrl())
                     .status(challengeMember.isOngoingYn() ? 1 : 0)
                     .totalAmount(total)
                     .recordList(recordList)
@@ -231,6 +233,7 @@ public class ChallengeService {
                 challengeMemberResultResponseList.add(ChallengeMemberResultResponse.builder()
                     .memberId(member.getId())
                     .nickname(member.getNickname())
+                    .profileImageUrl(member.getProfileImageUrl())
                     .status(total > challenge.getGoalAmount() ? 0 : 1)
                     .totalAmount(total)
                     .build());


### PR DESCRIPTION
- 프로필 이미지 url을 challengeMemberList에 추가

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 챌린지 단건 조회 시 챌린지 멤버 리스트에 프로필 이미지 url 추가

**TO-BE**

